### PR TITLE
docs: (#25) 게시물 API에 Swagger 문서화 적용

### DIFF
--- a/src/posts/dto/api-response.dto.ts
+++ b/src/posts/dto/api-response.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ApiResponseDto<T = any> {
+  @ApiProperty({
+    example: 'success',
+    description: '요청 처리 상태 (예: success / fail)',
+  })
+  status: string;
+
+  @ApiProperty({
+    example: '요청이 성공적으로 처리되었습니다.',
+    description: '서버에서 응답한 메시지',
+  })
+  message: string;
+
+  @ApiProperty({
+    description: '응답 데이터',
+    nullable: true,
+  })
+  data: T;
+}

--- a/src/posts/dto/create-post.dto.ts
+++ b/src/posts/dto/create-post.dto.ts
@@ -2,13 +2,20 @@ import { IsString, IsNotEmpty, MaxLength } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class CreatePostDto {
-  @ApiProperty({ description: '게시물 제목', maxLength: 255 })
+  @ApiProperty({
+    description: '게시물 제목',
+    maxLength: 255,
+    example: '2025년 6월 정모 안내',
+  })
   @IsString({ message: '제목은 문자열이어야 합니다.' })
   @IsNotEmpty({ message: '제목은 비워둘 수 없습니다.' })
   @MaxLength(255, { message: '제목은 최대 255자까지 입력할 수 있습니다.' })
   title: string;
 
-  @ApiProperty({ description: '게시물 내용' })
+  @ApiProperty({
+    description: '게시물 내용',
+    example: '인덕대학교 도서관 10시에 모입니다!',
+  })
   @IsString({ message: '내용은 문자열이어야 합니다.' })
   @IsNotEmpty({ message: '내용은 비워둘 수 없습니다.' })
   content: string;

--- a/src/posts/dto/res-post.dto.ts
+++ b/src/posts/dto/res-post.dto.ts
@@ -1,0 +1,37 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { UserInfoDto } from './user-info.dto';
+
+export class ResPostDto {
+  @ApiProperty({ example: 6, description: '게시물 ID' })
+  id: number;
+
+  @ApiProperty({ example: 29, description: '작성자 사용자 ID' })
+  userId: number;
+
+  @ApiProperty({ example: 1, description: '게시물이 속한 그룹 ID' })
+  groupId: number;
+
+  @ApiProperty({ example: '수정테스트!!', description: '게시물 제목' })
+  title: string;
+
+  @ApiProperty({ example: '수정테스트!!', description: '게시물 내용' })
+  content: string;
+
+  @ApiProperty({
+    example: '2025-05-16T02:35:57.282Z',
+    description: '게시물 생성 일자 (ISO 8601 형식)',
+  })
+  createdAt: Date;
+
+  @ApiProperty({
+    example: '2025-05-16T03:04:18.258Z',
+    description: '게시물 수정 일자 (ISO 8601 형식)',
+  })
+  updatedAt: Date;
+
+  @ApiProperty({
+    type: UserInfoDto,
+    description: '작성자 정보 (이름 등)',
+  })
+  user: UserInfoDto;
+}

--- a/src/posts/dto/update-post.dto.ts
+++ b/src/posts/dto/update-post.dto.ts
@@ -1,18 +1,4 @@
-import { PartialType, ApiProperty } from '@nestjs/swagger';
+import { PartialType } from '@nestjs/swagger';
 import { CreatePostDto } from './create-post.dto';
 
-export class UpdatePostDto extends PartialType(CreatePostDto) {
-  @ApiProperty({
-    description: '게시물 제목 (수정 가능)',
-    example: '수정된 제목입니다.',
-    required: false,
-  })
-  title?: string;
-
-  @ApiProperty({
-    description: '게시물 내용 (수정 가능)',
-    example: '수정된 내용입니다.',
-    required: false,
-  })
-  content?: string;
-}
+export class UpdatePostDto extends PartialType(CreatePostDto) {}

--- a/src/posts/dto/update-post.dto.ts
+++ b/src/posts/dto/update-post.dto.ts
@@ -1,4 +1,18 @@
-import { PartialType } from '@nestjs/swagger';
+import { PartialType, ApiProperty } from '@nestjs/swagger';
 import { CreatePostDto } from './create-post.dto';
 
-export class UpdatePostDto extends PartialType(CreatePostDto) {}
+export class UpdatePostDto extends PartialType(CreatePostDto) {
+  @ApiProperty({
+    description: '게시물 제목 (수정 가능)',
+    example: '수정된 제목입니다.',
+    required: false,
+  })
+  title?: string;
+
+  @ApiProperty({
+    description: '게시물 내용 (수정 가능)',
+    example: '수정된 내용입니다.',
+    required: false,
+  })
+  content?: string;
+}

--- a/src/posts/dto/user-info.dto.ts
+++ b/src/posts/dto/user-info.dto.ts
@@ -1,0 +1,6 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UserInfoDto {
+  @ApiProperty({ example: 'admin11', description: '작성자 이름' })
+  name: string;
+}

--- a/src/posts/post.swagger.ts
+++ b/src/posts/post.swagger.ts
@@ -1,0 +1,197 @@
+import { applyDecorators, Type } from '@nestjs/common';
+import {
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  getSchemaPath,
+  ApiExtraModels,
+} from '@nestjs/swagger';
+import { ResPostDto } from './dto/res-post.dto';
+import { ApiResponseDto } from './dto/api-response.dto';
+
+/**
+ * 인증 실패 공통 응답
+ */
+const unauthorizedResponse = () =>
+  ApiResponse({
+    status: 401,
+    description: '인증되지 않음 (JWT 토큰 없음 또는 유효하지 않음)',
+    content: {
+      'application/json': {
+        example: {
+          statusCode: 401,
+          message: 'Unauthorized',
+        },
+      },
+    },
+  });
+
+/**
+ * 공통 단일 객체 응답 스키마 생성
+ */
+function ApiResponseWithData<T extends Type<any>>(
+  model: T,
+  status = 200,
+  description = '요청이 성공적으로 처리되었습니다.',
+) {
+  return applyDecorators(
+    ApiExtraModels(ApiResponseDto, model),
+    ApiResponse({
+      status,
+      description,
+      schema: {
+        allOf: [
+          { $ref: getSchemaPath(ApiResponseDto) },
+          {
+            properties: {
+              data: { $ref: getSchemaPath(model) },
+            },
+          },
+        ],
+      },
+    }),
+  );
+}
+
+/**
+ * 공통 배열 객체 응답 스키마 생성
+ */
+function ApiArrayResponseWithData<T extends Type<any>>(
+  model: T,
+  status = 200,
+  description = '요청이 성공적으로 처리되었습니다.',
+) {
+  return applyDecorators(
+    ApiExtraModels(ApiResponseDto, model),
+    ApiResponse({
+      status,
+      description,
+      schema: {
+        allOf: [
+          { $ref: getSchemaPath(ApiResponseDto) },
+          {
+            properties: {
+              data: {
+                type: 'array',
+                items: { $ref: getSchemaPath(model) },
+              },
+            },
+          },
+        ],
+      },
+    }),
+  );
+}
+
+export const ApiPosts = {
+  create: () =>
+    applyDecorators(
+      ApiOperation({ summary: '게시물 생성' }),
+      ApiResponseWithData(
+        ResPostDto,
+        201,
+        '게시물이 성공적으로 생성되었습니다.',
+      ),
+      ApiResponse({
+        status: 400,
+        description: '잘못된 요청입니다.',
+        content: {
+          'application/json': {
+            example: {
+              statusCode: 400,
+              message: ['제목은 비워둘 수 없습니다.'],
+              error: 'Bad Request',
+            },
+          },
+        },
+      }),
+      unauthorizedResponse(),
+    ),
+
+  getAll: () =>
+    applyDecorators(
+      ApiOperation({ summary: '모든 게시물 조회' }),
+      ApiArrayResponseWithData(
+        ResPostDto,
+        200,
+        '게시물 목록을 성공적으로 가져왔습니다.',
+      ),
+      unauthorizedResponse(),
+    ),
+
+  getOne: () =>
+    applyDecorators(
+      ApiOperation({ summary: '특정 게시물 조회' }),
+      ApiResponseWithData(ResPostDto, 200, '게시물을 성공적으로 가져왔습니다.'),
+      ApiResponse({
+        status: 404,
+        description: '게시물을 찾을 수 없음',
+        content: {
+          'application/json': {
+            example: {
+              statusCode: 404,
+              message: '게시물 1을 찾을 수 없습니다.',
+              error: 'Not Found',
+            },
+          },
+        },
+      }),
+      unauthorizedResponse(),
+    ),
+
+  update: () =>
+    applyDecorators(
+      ApiOperation({ summary: '게시물 수정' }),
+      ApiResponseWithData(
+        ResPostDto,
+        200,
+        '게시물이 성공적으로 수정되었습니다.',
+      ),
+      ApiResponse({
+        status: 404,
+        description: '게시물을 찾을 수 없음',
+        content: {
+          'application/json': {
+            example: {
+              statusCode: 404,
+              message: '게시물 3을 찾을 수 없습니다.',
+              error: 'Not Found',
+            },
+          },
+        },
+      }),
+      unauthorizedResponse(),
+    ),
+
+  delete: () =>
+    applyDecorators(
+      ApiOperation({ summary: '게시물 삭제' }),
+      ApiResponse({
+        status: 200,
+        description: '게시물이 성공적으로 삭제됨',
+        content: {
+          'application/json': {
+            example: {
+              status: 'success',
+              message: '게시물이 성공적으로 삭제되었습니다.',
+              data: null,
+            },
+          },
+        },
+      }),
+      ApiResponse({
+        status: 404,
+        description: '게시물을 찾을 수 없음',
+        content: {
+          'application/json': {
+            example: {
+              statusCode: 404,
+              message: '게시물 2를 찾을 수 없습니다.',
+              error: 'Not Found',
+            },
+          },
+        },
+      }),
+      unauthorizedResponse(),
+    ),
+};

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -1,20 +1,21 @@
 import {
   Controller,
-  Get,
   Post,
-  Body,
+  Get,
   Patch,
-  Param,
   Delete,
-  ParseIntPipe,
-  UseGuards,
+  Param,
+  Body,
   Req,
+  UseGuards,
+  ParseIntPipe,
 } from '@nestjs/common';
 import { PostsService } from './posts.service';
 import { CreatePostDto } from './dto/create-post.dto';
 import { UpdatePostDto } from './dto/update-post.dto';
 import { Request } from 'express';
 import { CustomJwtAuthGuard } from 'src/auth/guards/custom-jwt-auth.guard';
+import { ApiPosts } from './post.swagger';
 
 @Controller('groups/:groupId/posts')
 @UseGuards(CustomJwtAuthGuard)
@@ -22,18 +23,14 @@ export class PostsController {
   constructor(private readonly postsService: PostsService) {}
 
   @Post()
+  @ApiPosts.create()
   async createPost(
     @Param('groupId', ParseIntPipe) groupId: number,
-    @Body() createPostDto: CreatePostDto,
+    @Body() dto: CreatePostDto,
     @Req() req: Request,
   ) {
-    const user = req.user as { userId: number };
-    const userId = user.userId;
-    const post = await this.postsService.createPost(
-      createPostDto,
-      groupId,
-      userId,
-    );
+    const userId = (req.user as any).userId;
+    const post = await this.postsService.createPost(dto, groupId, userId);
     return {
       status: 'success',
       message: '게시물이 성공적으로 생성되었습니다.',
@@ -42,6 +39,7 @@ export class PostsController {
   }
 
   @Get()
+  @ApiPosts.getAll()
   async getAllPosts(@Param('groupId', ParseIntPipe) groupId: number) {
     const posts = await this.postsService.getAllPosts(groupId);
     return {
@@ -52,6 +50,7 @@ export class PostsController {
   }
 
   @Get(':postId')
+  @ApiPosts.getOne()
   async getPostById(@Param('postId', ParseIntPipe) postId: number) {
     const post = await this.postsService.getPostById(postId);
     return {
@@ -62,32 +61,28 @@ export class PostsController {
   }
 
   @Patch(':postId')
+  @ApiPosts.update()
   async updatePost(
     @Param('postId', ParseIntPipe) postId: number,
-    @Body() updatePostDto: UpdatePostDto,
+    @Body() dto: UpdatePostDto,
     @Req() req: Request,
   ) {
-    const user = req.user as { userId: number };
-    const userId = user.userId;
-    const updatedPost = await this.postsService.updatePost(
-      updatePostDto,
-      postId,
-      userId,
-    );
+    const userId = (req.user as any).userId;
+    const post = await this.postsService.updatePost(dto, postId, userId);
     return {
       status: 'success',
       message: '게시물이 성공적으로 수정되었습니다.',
-      data: updatedPost,
+      data: post,
     };
   }
 
   @Delete(':postId')
+  @ApiPosts.delete()
   async deletePost(
     @Param('postId', ParseIntPipe) postId: number,
     @Req() req: Request,
   ) {
-    const user = req.user as { userId: number };
-    const userId = user.userId;
+    const userId = (req.user as any).userId;
     await this.postsService.deletePost(postId, userId);
     return {
       status: 'success',


### PR DESCRIPTION
관련 이슈
-
#25 

📝 제목
- 게시물 API Swagger 문서화 적용
<!-- [작업 유형] 작업 내용 요약 (ex: [Feature] 회원가입 API 개발) -->

📋 작업 내용
-
- [ ]  게시물 생성/조회/수정/삭제 API에 Swagger 문서화 적용
- [ ]  post.swagger.ts 생성 및 커스텀 응답 스키마 적용 
- [ ]  ResPostDto, CreatePostDto 등 DTO에 @ApiProperty 추가

🔧 기술 변경
- 없음
 <!-- 새로운 모듈/패키지 추가 -->
 <!-- 폴더/파일 구조 변경 -->

🚀 테스트 사항(선택)
- Swagger UI로 API 문서 확인 
- 커스텀 응답 형식 적용 여부 확인  
 <!--기능 테스트 완료 -->
 <!--API(Postman/Swagger) 테스트 -->
 <!-- 예외 처리 확인 -->
