### PR TITLE
refactor: (#17) 사용자 페이로드 구조 변경 및 JWT 전략 수정

### DIFF
--- a/src/auth/access.strategy.ts
+++ b/src/auth/access.strategy.ts
@@ -16,7 +16,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
 
   async validate(payload: any) {
     return {
-      userName: payload.sub,
+      userName: payload.userName,
       name: payload.name,
     };
   }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -51,7 +51,7 @@ export class AuthService {
     if (!isMatch) {
       throw new BadRequestException('아이디 또는 비밀번호가 틀렸습니다.');
     }
-    const payload = { sub: user.userName, name: user.name };
+    const payload = { sub: user.id, userName: user.userName, name: user.name };
     const accessToken = this.jwtService.sign(payload, {
       secret: this.configService.getOrThrow<string>('JWT_SECRET_KEY'),
       expiresIn: this.configService.getOrThrow<string>('JWT_ACCESS_EXPIRES_IN'),
@@ -79,7 +79,8 @@ export class AuthService {
         throw new BadRequestException('유효하지 않은 사용자입니다.');
       }
       const newAccessPayload = {
-        sub: user.userName,
+        sub: user.id,
+        userName: user.userName,
         name: user.name,
       };
       const accessToken = this.jwtService.sign(newAccessPayload, {


### PR DESCRIPTION
- accessToken의 payload에서 userId(sub)는 유지하되, validate 함수에서는 userId를 반환하지 않도록 변경
- access strategy에서 userName, name만 req.user에 포함되도록 수정

관련 이슈
- #17 

📝 제목
- 사용자 페이로드 구조 변경 및 JWT 전략 수정

📋 작업 내용
- [ ]  userName이 프론트에 전달되게 수정

🔧 기술 변경
-
 <!-- 새로운 모듈/패키지 추가 -->
 <!-- 폴더/파일 구조 변경 -->

🚀 테스트 사항(선택)
-
 <!--기능 테스트 완료 -->
 <!--API(Postman/Swagger) 테스트 -->
 <!-- 예외 처리 확인 -->

## 💬 리뷰 요구사항 (선택)  
<!-- 리뷰 요청 사항을 여기에 적어주세요 (선택사항) -->
