### PR TITLE
feat: (#38) 그룹 멤버/매니저 가드 추가 및 멤버 서비스·컨트롤러 구현

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,12 +7,14 @@ import { UserController } from './auth/user.controller';
 import { CommentsModule } from './comments/comments.module';
 import { PostsModule } from './posts/posts.module';
 import { PrismaModule } from './prisma/prisma.module';
+import { MemberModule } from './member/member.module';
 
 @Module({
   imports: [
     PrismaModule,
     AuthModule,
     PostsModule,
+    MemberModule,
     CommentsModule,
     ConfigModule.forRoot({
       isGlobal: true,

--- a/src/auth/access.strategy.ts
+++ b/src/auth/access.strategy.ts
@@ -16,6 +16,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
 
   async validate(payload: any) {
     return {
+      userId: payload.sub,
       userName: payload.userName,
       name: payload.name,
     };

--- a/src/member/guards/group-manager.guard.ts
+++ b/src/member/guards/group-manager.guard.ts
@@ -3,6 +3,7 @@ import {
   ExecutionContext,
   Injectable,
   ForbiddenException,
+  InternalServerErrorException,
 } from '@nestjs/common';
 import { MembersService } from '../member.service';
 
@@ -19,7 +20,7 @@ export class GroupManagerGuard implements CanActivate {
       throw new ForbiddenException('로그인이 필요합니다.');
     }
     if (!groupId) {
-      throw new ForbiddenException('그룹 정보가 올바르지 않습니다.');
+      throw new InternalServerErrorException('groupId 값이 필요합니다.');
     }
     const member = await this.membersService.getGroupMember(groupId, userId);
     if (!member || member.role !== 'manager') {

--- a/src/member/guards/group-manager.guard.ts
+++ b/src/member/guards/group-manager.guard.ts
@@ -1,0 +1,31 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  ForbiddenException,
+} from '@nestjs/common';
+import { MembersService } from '../member.service';
+
+@Injectable()
+export class GroupManagerGuard implements CanActivate {
+  constructor(private readonly membersService: MembersService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const groupId = Number(request.params.groupId);
+    const userId = request.user?.userId;
+
+    if (!userId) {
+      throw new ForbiddenException('로그인이 필요합니다.');
+    }
+    if (!groupId) {
+      throw new ForbiddenException('그룹 정보가 올바르지 않습니다.');
+    }
+    const member = await this.membersService.getGroupMember(groupId, userId);
+    if (!member || member.role !== 'manager') {
+      throw new ForbiddenException('이 그룹의 매니저만 접근할 수 있습니다.');
+    }
+
+    return true;
+  }
+}

--- a/src/member/guards/group-member.guard.ts
+++ b/src/member/guards/group-member.guard.ts
@@ -3,6 +3,7 @@ import {
   ExecutionContext,
   Injectable,
   ForbiddenException,
+  InternalServerErrorException,
 } from '@nestjs/common';
 import { MembersService } from '../member.service';
 
@@ -19,11 +20,13 @@ export class GroupMemberGuard implements CanActivate {
       throw new ForbiddenException('로그인이 필요합니다.');
     }
     if (!groupId) {
-      throw new ForbiddenException('그룹 정보가 올바르지 않습니다.');
+      throw new InternalServerErrorException('groupId 값이 필요합니다.');
     }
     const member = await this.membersService.getGroupMember(groupId, userId);
     if (!member) {
-      throw new ForbiddenException('이 그룹에 가입된 멤버만 조회할 수 있습니다.');
+      throw new ForbiddenException(
+        '이 그룹에 가입된 멤버만 조회할 수 있습니다.',
+      );
     }
 
     return true;

--- a/src/member/guards/group-member.guard.ts
+++ b/src/member/guards/group-member.guard.ts
@@ -1,0 +1,31 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  ForbiddenException,
+} from '@nestjs/common';
+import { MembersService } from '../member.service';
+
+@Injectable()
+export class GroupMemberGuard implements CanActivate {
+  constructor(private readonly membersService: MembersService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const groupId = Number(request.params.groupId);
+    const userId = request.user?.userId;
+
+    if (!userId) {
+      throw new ForbiddenException('로그인이 필요합니다.');
+    }
+    if (!groupId) {
+      throw new ForbiddenException('그룹 정보가 올바르지 않습니다.');
+    }
+    const member = await this.membersService.getGroupMember(groupId, userId);
+    if (!member) {
+      throw new ForbiddenException('이 그룹에 가입된 멤버만 조회할 수 있습니다.');
+    }
+
+    return true;
+  }
+}

--- a/src/member/member.controller.ts
+++ b/src/member/member.controller.ts
@@ -1,0 +1,45 @@
+import {
+  Controller,
+  Get,
+  Param,
+  ParseIntPipe,
+  Req,
+  Delete,
+  UseGuards,
+} from '@nestjs/common';
+import { MembersService } from './member.service';
+import { GroupManagerGuard } from './guards/group-manager.guard';
+import { GroupMemberGuard } from './guards/group-member.guard';
+
+@Controller('groups/:groupId/memberlist')
+export class MembersController {
+  constructor(private readonly membersService: MembersService) {}
+
+  @UseGuards(GroupMemberGuard)
+  @Get()
+  async getMemberList(@Param('groupId', ParseIntPipe) groupId: number) {
+    return this.membersService.getMemberList(groupId);
+  }
+
+  // 그룹 멤버 조회 (멤버만 조회 가능)
+  @UseGuards(GroupMemberGuard)
+  @Get(':userId')
+  async getGroupMember(
+    @Param('groupId', ParseIntPipe) groupId: number,
+    @Param('userId', ParseIntPipe) userId: number,
+  ) {
+    return this.membersService.getGroupMember(groupId, userId);
+  }
+
+  // 그룹 매니저만 멤버 삭제 가능
+  @UseGuards(GroupManagerGuard)
+  @Delete(':userId')
+  async removeMember(
+    @Param('groupId', ParseIntPipe) groupId: number,
+    @Param('userId', ParseIntPipe) userId: number,
+    @Req() req,
+  ) {
+    const requesterUserId = req.user.userId;
+    return this.membersService.removeMember(groupId, userId, requesterUserId);
+  }
+}

--- a/src/member/member.controller.ts
+++ b/src/member/member.controller.ts
@@ -10,19 +10,20 @@ import {
 import { MembersService } from './member.service';
 import { GroupManagerGuard } from './guards/group-manager.guard';
 import { GroupMemberGuard } from './guards/group-member.guard';
+import { CustomJwtAuthGuard } from 'src/auth/guards/access.guard';
 
-@Controller('groups/:groupId/memberlist')
+@Controller('groups/:groupId/members')
 export class MembersController {
   constructor(private readonly membersService: MembersService) {}
 
-  @UseGuards(GroupMemberGuard)
+  @UseGuards(CustomJwtAuthGuard, GroupMemberGuard)
   @Get()
   async getMemberList(@Param('groupId', ParseIntPipe) groupId: number) {
     return this.membersService.getMemberList(groupId);
   }
 
   // 그룹 멤버 조회 (멤버만 조회 가능)
-  @UseGuards(GroupMemberGuard)
+  @UseGuards(CustomJwtAuthGuard, GroupMemberGuard)
   @Get(':userId')
   async getGroupMember(
     @Param('groupId', ParseIntPipe) groupId: number,
@@ -32,7 +33,7 @@ export class MembersController {
   }
 
   // 그룹 매니저만 멤버 삭제 가능
-  @UseGuards(GroupManagerGuard)
+  @UseGuards(CustomJwtAuthGuard, GroupManagerGuard)
   @Delete(':userId')
   async removeMember(
     @Param('groupId', ParseIntPipe) groupId: number,

--- a/src/member/member.module.ts
+++ b/src/member/member.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { MembersController } from './member.controller';
+import { MembersService } from './member.service';
+
+@Module({
+  controllers: [MembersController],
+  providers: [MembersService],
+})
+export class MemberModule {}

--- a/src/member/member.service.ts
+++ b/src/member/member.service.ts
@@ -16,12 +16,14 @@ export class MembersService {
       },
     });
 
-    return members.map((member) => ({
-      userId: member.userId,
-      name: member.user.name,
-      role: member.role,
-      joinedAt: member.createdAt,
-    }));
+    return members
+      .filter((member) => member.role !== 'admin')
+      .map((member) => ({
+        userId: member.userId,
+        name: member.user.name,
+        role: member.role,
+        joinedAt: member.createdAt,
+      }));
   }
 
   async getGroupMember(groupId: number, userId: number) {
@@ -36,8 +38,7 @@ export class MembersService {
     });
   }
 
-  // manager만 멤버 삭제 가능
-  async removeMember(
+  async validateRemoveMember(
     groupId: number,
     targetUserId: number,
     requesterUserId: number,
@@ -67,6 +68,20 @@ export class MembersService {
     if (!targetMember) {
       throw new ForbiddenException('삭제할 멤버가 존재하지 않습니다.');
     }
+
+    return targetMember;
+  }
+
+  async removeMember(
+    groupId: number,
+    targetUserId: number,
+    requesterUserId: number,
+  ) {
+    const targetMember = await this.validateRemoveMember(
+      groupId,
+      targetUserId,
+      requesterUserId,
+    );
 
     return this.prisma.userGroup.delete({
       where: {

--- a/src/member/member.service.ts
+++ b/src/member/member.service.ts
@@ -1,0 +1,77 @@
+import { ForbiddenException, Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+@Injectable()
+export class MembersService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async getMemberList(groupId: number) {
+    const members = await this.prisma.userGroup.findMany({
+      where: { groupId },
+      include: {
+        user: true,
+      },
+      orderBy: {
+        createdAt: 'asc',
+      },
+    });
+
+    return members.map((member) => ({
+      userId: member.userId,
+      name: member.user.name,
+      role: member.role,
+      joinedAt: member.createdAt,
+    }));
+  }
+
+  async getGroupMember(groupId: number, userId: number) {
+    return this.prisma.userGroup.findFirst({
+      where: {
+        groupId,
+        userId,
+      },
+      include: {
+        user: true,
+      },
+    });
+  }
+
+  // manager만 멤버 삭제 가능
+  async removeMember(
+    groupId: number,
+    targetUserId: number,
+    requesterUserId: number,
+  ) {
+    if (targetUserId === requesterUserId) {
+      throw new ForbiddenException('자신을 삭제할 수 없습니다.');
+    }
+
+    const requester = await this.prisma.userGroup.findFirst({
+      where: {
+        groupId,
+        userId: requesterUserId,
+      },
+    });
+
+    if (!requester || requester.role !== 'manager') {
+      throw new ForbiddenException('매니저만 멤버를 삭제할 수 있습니다.');
+    }
+
+    const targetMember = await this.prisma.userGroup.findFirst({
+      where: {
+        groupId,
+        userId: targetUserId,
+      },
+    });
+
+    if (!targetMember) {
+      throw new ForbiddenException('삭제할 멤버가 존재하지 않습니다.');
+    }
+
+    return this.prisma.userGroup.delete({
+      where: {
+        id: targetMember.id,
+      },
+    });
+  }
+}


### PR DESCRIPTION
- 그룹 멤버만 접근 가능한 GroupMemberGuard 가드 구현
- 그룹 매니저만 접근 가능한 GroupManagerGuard 가드 구현
- 멤버 리스트/정보 조회, 멤버 삭제 기능을 포함한 MembersService 및 MembersController 작성

관련 이슈
- #38 

📝 제목
- 멤버/매니저 가드 추가 및 서비스, 컨트롤러 구현
<!-- [작업 유형] 작업 내용 요약 (ex: [Feature] 회원가입 API 개발) -->

📋 작업 내용
- [ ]  매니저 권한(멤버 삭제) 생성
- [ ]  그룹 멤버/매니저 가드 생성
- [ ]  멤버 리스트/ 정보 조회 기능 생성

🔧 기술 변경
-
 <!-- 새로운 모듈/패키지 추가 -->
 <!-- 폴더/파일 구조 변경 -->

🚀 테스트 사항(선택)
- 기능 테스트 예정
 <!--기능 테스트 완료 -->
 <!--API(Postman/Swagger) 테스트 -->
 <!-- 예외 처리 확인 -->

## 💬 리뷰 요구사항 (선택)  
<!-- 리뷰 요청 사항을 여기에 적어주세요 (선택사항) -->
코드 구조가 어떤지 한번 봐주고 말씀해주세요!
