### PR TITLE
feat: (#34) 게시글 응답에 userId, commentsCount 추가 및 Swagger 인증 설정

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -32,12 +32,22 @@ async function bootstrap() {
     .setTitle('모동구')
     .setDescription('모동구 API 명세서')
     .setVersion('1.0')
+    .addBearerAuth(
+      {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+        name: 'Authorization',
+        in: 'header',
+      },
+      'access-token',
+    )
     .setTermsOfService('https://github.com/modern-agile-team/9term-main-back')
     .addTag('모동구')
     .build();
-  const documentFactory = () => SwaggerModule.createDocument(app, config);
 
-  SwaggerModule.setup('api', app, documentFactory);
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('api', app, document);
 
   await app.listen(process.env.PORT ?? 3000);
 }

--- a/src/posts/dto/res-post.dto.ts
+++ b/src/posts/dto/res-post.dto.ts
@@ -5,33 +5,27 @@ export class ResPostDto {
   @ApiProperty({ example: 6, description: '게시물 ID' })
   id: number;
 
-  @ApiProperty({ example: 29, description: '작성자 사용자 ID' })
-  userId: number;
-
-  @ApiProperty({ example: 1, description: '게시물이 속한 그룹 ID' })
+  @ApiProperty({ example: 1, description: '그룹 ID' })
   groupId: number;
 
-  @ApiProperty({ example: '수정테스트!!', description: '게시물 제목' })
+  @ApiProperty({ example: '제목', description: '게시물 제목' })
   title: string;
 
-  @ApiProperty({ example: '수정테스트!!', description: '게시물 내용' })
+  @ApiProperty({ example: '본문', description: '게시물 내용' })
   content: string;
 
-  @ApiProperty({
-    example: '2025-05-16T02:35:57.282Z',
-    description: '게시물 생성 일자 (ISO 8601 형식)',
-  })
+  @ApiProperty({ example: '2025-06-27T05:25:37.078Z', description: '작성일시' })
   createdAt: Date;
 
-  @ApiProperty({
-    example: '2025-05-16T03:04:18.258Z',
-    description: '게시물 수정 일자 (ISO 8601 형식)',
-  })
-  updatedAt: Date;
+  @ApiProperty({ example: null, description: '수정일시' })
+  updatedAt: Date | null;
 
   @ApiProperty({
     type: UserInfoDto,
-    description: '작성자 정보 (이름 등)',
+    description: '작성자 정보 (id, name)',
   })
   user: UserInfoDto;
+
+  @ApiProperty({ example: 3, description: '댓글 수' })
+  commentsCount: number;
 }

--- a/src/posts/dto/user-info.dto.ts
+++ b/src/posts/dto/user-info.dto.ts
@@ -1,6 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger';
 
 export class UserInfoDto {
-  @ApiProperty({ example: 'admin11', description: '작성자 이름' })
+  @ApiProperty({ example: 1, description: '작성자 ID' })
+  id: number;
+
+  @ApiProperty({ example: '정윤호', description: '작성자 이름' })
   name: string;
 }

--- a/src/posts/post.swagger.ts
+++ b/src/posts/post.swagger.ts
@@ -1,5 +1,6 @@
 import { applyDecorators, Type } from '@nestjs/common';
 import {
+  ApiBearerAuth,
   ApiExtraModels,
   ApiOperation,
   ApiResponse,
@@ -85,6 +86,7 @@ function ApiArrayResponseWithData<T extends Type<any>>(
 export const ApiPosts = {
   create: () =>
     applyDecorators(
+      ApiBearerAuth('access-token'),
       ApiOperation({ summary: '게시물 생성' }),
       ApiResponseWithData(
         ResPostDto,
@@ -109,6 +111,7 @@ export const ApiPosts = {
 
   getAll: () =>
     applyDecorators(
+      ApiBearerAuth('access-token'),
       ApiOperation({ summary: '모든 게시물 조회' }),
       ApiArrayResponseWithData(
         ResPostDto,
@@ -120,6 +123,7 @@ export const ApiPosts = {
 
   getOne: () =>
     applyDecorators(
+      ApiBearerAuth('access-token'),
       ApiOperation({ summary: '특정 게시물 조회' }),
       ApiResponseWithData(ResPostDto, 200, '게시물을 성공적으로 가져왔습니다.'),
       ApiResponse({
@@ -140,6 +144,7 @@ export const ApiPosts = {
 
   update: () =>
     applyDecorators(
+      ApiBearerAuth('access-token'),
       ApiOperation({ summary: '게시물 수정' }),
       ApiResponseWithData(
         ResPostDto,
@@ -164,6 +169,7 @@ export const ApiPosts = {
 
   delete: () =>
     applyDecorators(
+      ApiBearerAuth('access-token'),
       ApiOperation({ summary: '게시물 삭제' }),
       ApiResponse({
         status: 200,

--- a/src/posts/posts.repository.ts
+++ b/src/posts/posts.repository.ts
@@ -23,7 +23,13 @@ export class PostsRepository {
       include: {
         user: {
           select: {
+            id: true,
             name: true,
+          },
+        },
+        _count: {
+          select: {
+            comments: true,
           },
         },
       },
@@ -36,13 +42,18 @@ export class PostsRepository {
       include: {
         user: {
           select: {
+            id: true,
             name: true,
+          },
+        },
+        _count: {
+          select: {
+            comments: true,
           },
         },
       },
     });
   }
-
   async updatePostById(id: number, data: { title?: string; content?: string }) {
     return await this.prisma.post.update({
       where: { id },

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -54,7 +54,7 @@ export class PostsService {
       createdAt: post.createdAt,
       updatedAt: post.updatedAt,
       user: post.user,
-      commentsCount: post._count.comments, // ✅ 댓글 수 포함
+      commentsCount: post._count.comments,
     };
   }
 

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -35,7 +35,7 @@ export class PostsService {
       createdAt: post.createdAt,
       updatedAt: post.updatedAt,
       user: post.user,
-      commentsCount: post._count.comments, // 추가된 부분
+      commentsCount: post._count.comments,
     }));
   }
 

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -26,7 +26,17 @@ export class PostsService {
   }
 
   async getAllPosts(groupId: number) {
-    return await this.postsRepository.findPostsByGroupId(groupId);
+    const posts = await this.postsRepository.findPostsByGroupId(groupId);
+
+    return posts.map((post) => ({
+      id: post.id,
+      title: post.title,
+      content: post.content,
+      createdAt: post.createdAt,
+      updatedAt: post.updatedAt,
+      user: post.user,
+      commentsCount: post._count.comments, // 추가된 부분
+    }));
   }
 
   async getPostById(id: number) {
@@ -34,7 +44,18 @@ export class PostsService {
     if (!post) {
       throw new NotFoundException(`ID가 ${id}인 게시물을 찾을 수 없습니다.`);
     }
-    return post;
+
+    return {
+      id: post.id,
+      userId: post.userId,
+      groupId: post.groupId,
+      title: post.title,
+      content: post.content,
+      createdAt: post.createdAt,
+      updatedAt: post.updatedAt,
+      user: post.user,
+      commentsCount: post._count.comments, // ✅ 댓글 수 포함
+    };
   }
 
   async updatePost(updatePostDto: UpdatePostDto, id: number, userId: number) {


### PR DESCRIPTION
관련 이슈
-
#34 

📝 제목
-
[Feature] 게시글 응답 확장 및 Swagger 인증 기능 추가

📋 작업 내용
-
- [ ]   게시글 응답에 userId, commentsCount 필드 추가
- [ ]  Swagger에서 JWT 토큰 입력 가능하도록 BearerAuth 설정
- [ ] @ApiBearerAuth('access-token') 명시하여 문서에서 인증 테스트 가능

🔧 기술 변경
- Swagger 인증 설정 (addBearerAuth, @ApiBearerAuth)
- 게시글 응답 DTO 수정 (ResPostDto)

🚀 테스트 사항
- [ ]  Swagger에서 토큰 입력 후 게시글 API 테스트 성공
- [ ] 응답에 userId, commentsCount 정상 포함 확인
- [ ] 인증 실패 시 401 응답 확인