### PR TITLE
refactor: (#38) 그룹 멤버 관리 기능 개선

### DIFF
--- a/src/auth/user.controller.ts
+++ b/src/auth/user.controller.ts
@@ -58,6 +58,7 @@ export class UserController {
       status: 'success',
       message: '내 정보 조회 성공',
       data: {
+        userId: req.user.userId,
         name: req.user.name,
         userName: req.user.userName,
       },

--- a/src/auth/user.dto.ts
+++ b/src/auth/user.dto.ts
@@ -1,6 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger';
 
 export class UserProfileDto {
+  @ApiProperty({ example: 1, description: '사용자 ID' })
+  userId: number;
+
   @ApiProperty({ example: '정윤호', description: '사용자 아이디' })
   name: string;
 

--- a/src/groups/dto/join-group.dto.ts
+++ b/src/groups/dto/join-group.dto.ts
@@ -1,13 +1,15 @@
-import { IsNumber, IsString, IsNotEmpty } from 'class-validator';
+import { IsNumber, IsString, IsNotEmpty, IsOptional } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class JoinGroupDto {
   @ApiProperty({ description: '사용자 ID', example: 1 })
   @IsNumber()
+  @IsOptional()
   userId: number;
 
   @ApiProperty({ description: '그룹 ID', example: 10 })
   @IsNumber()
+  @IsOptional()
   groupId: number;
 
   @ApiProperty({

--- a/src/groups/groups.module.ts
+++ b/src/groups/groups.module.ts
@@ -2,9 +2,12 @@ import { Module } from '@nestjs/common';
 import { GroupsService } from './groups.service';
 import { GroupsController } from './groups.controller';
 import { GroupsRepository } from './groups.repository';
+import { MembersService } from '../member/member.service';
+import { MemberModule } from '../member/member.module';
 
 @Module({
+  imports: [MemberModule],
   controllers: [GroupsController],
-  providers: [GroupsService, GroupsRepository],
+  providers: [GroupsService, GroupsRepository, MembersService],
 })
 export class GroupsModule {}

--- a/src/groups/groups.service.ts
+++ b/src/groups/groups.service.ts
@@ -13,15 +13,15 @@ import { GroupResponseDto } from './dto/group-response.dto';
 import { GroupWithMemberCountDto } from './dto/group-with-member-count.dto';
 import { GroupJoinStatusDto } from './dto/group-join-status.dto';
 import { GroupUserResponseDto } from './dto/group-user-response.dto';
-import {
-  CreateGroupInput,
-  GroupUserInput,
-  UpdateGroupInput,
-} from './types/group-inputs';
+import { CreateGroupInput, UpdateGroupInput } from './types/group-inputs';
+import { MembersService } from '../member/member.service';
 
 @Injectable()
 export class GroupsService {
-  constructor(private readonly groupsRepository: GroupsRepository) {}
+  constructor(
+    private readonly groupsRepository: GroupsRepository,
+    private readonly membersService: MembersService,
+  ) {}
 
   async createGroup(
     createGroupDto: CreateGroupDto,
@@ -110,26 +110,7 @@ export class GroupsService {
   }
 
   async joinGroup(joinGroupDto: JoinGroupDto): Promise<GroupUserResponseDto> {
-    const { groupId, userId } = joinGroupDto;
-
-    const existingMembership = await this.groupsRepository.findGroupUser(
-      groupId,
-      userId,
-    );
-
-    if (existingMembership) {
-      throw new ConflictException('이미 이 그룹에 가입되어 있습니다.');
-    }
-
-    const groupUserData: GroupUserInput = {
-      userId,
-      groupId,
-      role: 'member',
-    };
-
-    const createdGroupUser =
-      await this.groupsRepository.createGroupUser(groupUserData);
-
+    const createdGroupUser = await this.membersService.joinGroup(joinGroupDto);
     return plainToInstance(GroupUserResponseDto, createdGroupUser, {
       excludeExtraneousValues: true,
     });

--- a/src/member/dto/member-request.dto.ts
+++ b/src/member/dto/member-request.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-export class MemberRequestDto {
+export class JoinMemberRequestDto {
   @ApiProperty({ example: 10, description: '그룹 ID' })
   groupId: number;
 

--- a/src/member/dto/member-request.dto.ts
+++ b/src/member/dto/member-request.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class MemberRequestDto {
+  @ApiProperty({ example: 10, description: '그룹 ID' })
+  groupId: number;
+
+  @ApiProperty({
+    example: 'member',
+    description: '그룹 내 역할',
+    required: false,
+  })
+  role?: string;
+}

--- a/src/member/dto/member-response.dto.ts
+++ b/src/member/dto/member-response.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class MemberResponseDto {
+  @ApiProperty({ example: 1, description: '사용자 ID' })
+  userId: number;
+
+  @ApiProperty({ example: '정윤호', description: '사용자 이름' })
+  name: string;
+
+  @ApiProperty({ example: 'member', description: '그룹 내 역할' })
+  role: string;
+
+  @ApiProperty({
+    example: '2024-07-02T12:34:56.000Z',
+    description: '가입 일시',
+  })
+  joinedAt: Date;
+}

--- a/src/member/guards/group-manager.guard.ts
+++ b/src/member/guards/group-manager.guard.ts
@@ -17,7 +17,7 @@ export class GroupManagerGuard implements CanActivate {
     const request = context.switchToHttp().getRequest<Request>();
     const groupId: number = Number(request.params.groupId);
     const user = request.user as AuthenticatedUser;
-    const userId: number = user.userId;
+    const userId = user.userId;
 
     if (!groupId) {
       throw new InternalServerErrorException('groupId 값이 필요합니다.');

--- a/src/member/guards/group-manager.guard.ts
+++ b/src/member/guards/group-manager.guard.ts
@@ -7,7 +7,7 @@ import {
 } from '@nestjs/common';
 import { MembersService } from '../member.service';
 import { Request } from 'express';
-import { GroupMember } from '../interfaces/member.interface';
+import { AuthenticatedUser } from '../../auth/interfaces/authenticated-user.interface';
 
 @Injectable()
 export class GroupManagerGuard implements CanActivate {
@@ -16,11 +16,9 @@ export class GroupManagerGuard implements CanActivate {
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest<Request>();
     const groupId: number = Number(request.params.groupId);
-    const userId: number | undefined = (request.user as GroupMember)?.userId;
+    const user = request.user as AuthenticatedUser;
+    const userId: number = user.userId;
 
-    if (!userId) {
-      throw new ForbiddenException('로그인이 필요합니다.');
-    }
     if (!groupId) {
       throw new InternalServerErrorException('groupId 값이 필요합니다.');
     }

--- a/src/member/guards/group-member.guard.ts
+++ b/src/member/guards/group-member.guard.ts
@@ -16,12 +16,9 @@ export class GroupMemberGuard implements CanActivate {
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest<Request>();
     const groupId = Number(request.params.groupId);
-    const user = request.user as AuthenticatedUser | undefined;
+    const user = request.user as AuthenticatedUser;
     const userId = user?.userId;
 
-    if (!userId) {
-      throw new ForbiddenException('로그인이 필요합니다.');
-    }
     if (!groupId) {
       throw new InternalServerErrorException('groupId 값이 필요합니다.');
     }

--- a/src/member/interfaces/member.interface.ts
+++ b/src/member/interfaces/member.interface.ts
@@ -9,3 +9,10 @@ export interface Member {
 export interface GroupMember extends Member {
   groupId: number;
 }
+
+export interface UserGroup {
+  userId: number;
+  groupId: number;
+  role: string;
+  createdAt: Date;
+}

--- a/src/member/member.controller.ts
+++ b/src/member/member.controller.ts
@@ -6,6 +6,7 @@ import {
   Req,
   Delete,
   UseGuards,
+  ForbiddenException,
 } from '@nestjs/common';
 import { Request } from 'express';
 import { MembersService } from './member.service';
@@ -43,7 +44,9 @@ export class MembersController {
     @Req() req: Request,
   ) {
     const requesterUserId = (req.user as AuthenticatedUser)?.userId;
-
-    return this.membersService.removeMember(groupId, userId, requesterUserId);
+    if (userId === requesterUserId) {
+      throw new ForbiddenException('자신을 삭제할 수 없습니다.');
+    }
+    return this.membersService.processRemoveMember(groupId, userId);
   }
 }

--- a/src/member/member.module.ts
+++ b/src/member/member.module.ts
@@ -2,11 +2,10 @@ import { Module } from '@nestjs/common';
 import { MembersController } from './member.controller';
 import { MembersService } from './member.service';
 import { MemberRepository } from './member.repository';
-import { PrismaService } from '../prisma/prisma.service';
 
 @Module({
   controllers: [MembersController],
-  providers: [MembersService, MemberRepository, PrismaService],
+  providers: [MembersService, MemberRepository],
   exports: [MembersService, MemberRepository],
 })
 export class MemberModule {}

--- a/src/member/member.module.ts
+++ b/src/member/member.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
 import { MembersController } from './member.controller';
 import { MembersService } from './member.service';
+import { MemberRepository } from './member.repository';
+import { PrismaService } from '../prisma/prisma.service';
 
 @Module({
   controllers: [MembersController],
-  providers: [MembersService],
+  providers: [MembersService, MemberRepository, PrismaService],
 })
 export class MemberModule {}

--- a/src/member/member.module.ts
+++ b/src/member/member.module.ts
@@ -7,5 +7,6 @@ import { PrismaService } from '../prisma/prisma.service';
 @Module({
   controllers: [MembersController],
   providers: [MembersService, MemberRepository, PrismaService],
+  exports: [MembersService, MemberRepository],
 })
 export class MemberModule {}

--- a/src/member/member.repository.ts
+++ b/src/member/member.repository.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { UserGroup } from './interfaces/member.interface';
+
+@Injectable()
+export class MemberRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findGroupMember(
+    groupId: number,
+    userId: number,
+  ): Promise<UserGroup | null> {
+    return this.prisma.userGroup.findFirst({
+      where: {
+        groupId,
+        userId,
+      },
+    });
+  }
+
+  async findAllMembersByGroup(groupId: number): Promise<UserGroup[]> {
+    return this.prisma.userGroup.findMany({
+      where: { groupId },
+    });
+  }
+
+  async deleteMemberById(id: number) {
+    return this.prisma.userGroup.delete({
+      where: { id },
+    });
+  }
+}

--- a/src/member/member.repository.ts
+++ b/src/member/member.repository.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { UserGroup } from './interfaces/member.interface';
+import { User } from '@prisma/client';
 
 @Injectable()
 export class MemberRepository {
@@ -9,7 +10,7 @@ export class MemberRepository {
   async findGroupMember(
     groupId: number,
     userId: number,
-  ): Promise<(UserGroup & { user?: { name: string } }) | null> {
+  ): Promise<(UserGroup & { user: User }) | null> {
     return this.prisma.userGroup.findFirst({
       where: {
         groupId,
@@ -41,7 +42,7 @@ export class MemberRepository {
     });
   }
 
-  async deleteMember(groupId: number, userId: number) {
+  async deleteManyByGroupAndUser(groupId: number, userId: number) {
     return this.prisma.userGroup.deleteMany({
       where: { groupId, userId },
     });

--- a/src/member/member.repository.ts
+++ b/src/member/member.repository.ts
@@ -9,24 +9,41 @@ export class MemberRepository {
   async findGroupMember(
     groupId: number,
     userId: number,
-  ): Promise<UserGroup | null> {
+  ): Promise<(UserGroup & { user?: { name: string } }) | null> {
     return this.prisma.userGroup.findFirst({
       where: {
         groupId,
         userId,
       },
+      include: {
+        user: true,
+      },
     });
   }
 
-  async findAllMembersByGroup(groupId: number): Promise<UserGroup[]> {
+  async findAllMembersByGroup(
+    groupId: number,
+  ): Promise<(UserGroup & { user?: { name: string } })[]> {
     return this.prisma.userGroup.findMany({
       where: { groupId },
+      include: {
+        user: true,
+      },
     });
   }
 
-  async deleteMemberById(id: number) {
-    return this.prisma.userGroup.delete({
-      where: { id },
+  async createMember(data: { groupId: number; userId: number; role: string }) {
+    return this.prisma.userGroup.create({
+      data,
+      include: {
+        user: true,
+      },
+    });
+  }
+
+  async deleteMember(groupId: number, userId: number) {
+    return this.prisma.userGroup.deleteMany({
+      where: { groupId, userId },
     });
   }
 }

--- a/src/member/member.service.ts
+++ b/src/member/member.service.ts
@@ -1,59 +1,91 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
-import { PrismaService } from 'src/prisma/prisma.service';
+import {
+  Injectable,
+  NotFoundException,
+  ConflictException,
+} from '@nestjs/common';
+import { MemberRepository } from './member.repository';
+import { MemberRequestDto } from './dto/member-request.dto';
+import { MemberResponseDto } from './dto/member-response.dto';
 
 @Injectable()
 export class MembersService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(private readonly memberRepository: MemberRepository) {}
 
-  async getMemberList(groupId: number) {
-    const members = await this.prisma.userGroup.findMany({
-      where: { groupId },
-      include: {
-        user: true,
-      },
-      orderBy: {
-        createdAt: 'asc',
-      },
-    });
+  async getMemberList(groupId: number): Promise<MemberResponseDto[]> {
+    const members = await this.memberRepository.findAllMembersByGroup(groupId);
 
     return members
       .filter((member) => member.role !== 'admin')
       .map((member) => ({
         userId: member.userId,
-        name: member.user.name,
+        name: member.user?.name ?? '',
         role: member.role,
         joinedAt: member.createdAt,
       }));
   }
 
-  async getGroupMember(groupId: number, userId: number) {
-    return this.prisma.userGroup.findFirst({
-      where: {
-        groupId,
-        userId,
-      },
-      include: {
-        user: true,
-      },
-    });
+  async getGroupMember(
+    groupId: number,
+    userId: number,
+  ): Promise<MemberResponseDto | null> {
+    const member = await this.memberRepository.findGroupMember(groupId, userId);
+    if (!member) {
+      return null;
+    }
+    return {
+      userId: member.userId,
+      name: member.user?.name ?? '',
+      role: member.role,
+      joinedAt: member.createdAt,
+    };
   }
 
-  async removeMember(id: number) {
-    return this.prisma.userGroup.delete({
-      where: { id },
-    });
-  }
-
-  async processRemoveMember(groupId: number, targetUserId: number) {
-    const targetMember = await this.prisma.userGroup.findFirst({
-      where: {
-        groupId,
-        userId: targetUserId,
-      },
-    });
+  async processRemoveMember(
+    groupId: number,
+    targetUserId: number,
+  ): Promise<MemberResponseDto> {
+    const targetMember = await this.memberRepository.findGroupMember(
+      groupId,
+      targetUserId,
+    );
     if (!targetMember) {
       throw new NotFoundException('삭제할 멤버가 존재하지 않습니다.');
     }
-    return this.removeMember(targetMember.id);
+    await this.removeMember(targetMember.groupId, targetMember.userId);
+    return {
+      userId: targetMember.userId,
+      name: targetMember.user?.name ?? '',
+      role: targetMember.role,
+      joinedAt: targetMember.createdAt,
+    };
+  }
+
+  async removeMember(groupId: number, userId: number): Promise<void> {
+    await this.memberRepository.deleteMember(groupId, userId);
+  }
+
+  async joinGroup(
+    dto: MemberRequestDto & { userId: number },
+  ): Promise<MemberResponseDto> {
+    const { groupId, userId, role } = dto;
+    const existingMembership = await this.memberRepository.findGroupMember(
+      groupId,
+      userId,
+    );
+    if (existingMembership) {
+      throw new ConflictException('이미 이 그룹에 가입되어 있습니다.');
+    }
+    const createdGroupUser = await this.memberRepository.createMember({
+      groupId,
+      userId,
+      role: role ?? 'member',
+    });
+
+    return {
+      userId: createdGroupUser.userId,
+      name: createdGroupUser.user?.name ?? '',
+      role: createdGroupUser.role,
+      joinedAt: createdGroupUser.createdAt,
+    };
   }
 }


### PR DESCRIPTION
- 서비스에서 권한 검증, 자신 삭제 방지 등 비즈니스 검증 로직을 컨트롤러/가드로 분리
- admin/manager 권한 정책을 명확히 하고, 예외 처리 일관성 강화
- 사용하지 않는 인터페이스 필드(id 등) 제거 및 타입 통일

관련 이슈
- #38 

📝 제목
- member 권한 리팩토링
<!-- [작업 유형] 작업 내용 요약 (ex: [Feature] 회원가입 API 개발) -->

📋 작업 내용
- [ ]  서비스에서 비즈니스 검증 로직 분리 
- [ ]  admin/manager 권한 명확히 변경 
- [ ]  인터페이스를 생성하여 타입 명시

🔧 기술 변경
-
 <!-- 새로운 모듈/패키지 추가 -->
 <!-- 폴더/파일 구조 변경 -->

🚀 테스트 사항(선택)
- 
 <!--기능 테스트 완료 -->
 <!--API(Postman/Swagger) 테스트 -->
 <!-- 예외 처리 확인 -->

## 💬 리뷰 요구사항 (선택)  
<!-- 리뷰 요청 사항을 여기에 적어주세요 (선택사항) -->
