### PR TITLE
docs: (#45) 댓글 API Swagger 문서화

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,12 +1,12 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
+import { InternalServerErrorException } from '@nestjs/common/exceptions/internal-server-error.exception';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import { LoginRequestDto } from './dto/login-request.dto';
 import { SignupRequestDto } from './dto/signup-request.dto';
+import { JwtPayload } from './interfaces/jwt-payload.interface';
 import { PasswordEncoderService } from './password-encoder.service';
 import { UserRepository } from './user.repository';
-import { JwtPayload } from './interfaces/jwt-payload.interface';
-import { InternalServerErrorException } from '@nestjs/common/exceptions/internal-server-error.exception';
 
 @Injectable()
 export class AuthService {
@@ -53,7 +53,11 @@ export class AuthService {
     if (!isMatch) {
       throw new BadRequestException('아이디 또는 비밀번호가 틀렸습니다.');
     }
-    const payload = { sub: user.id, userName: user.userName, name: user.name };
+    const payload: JwtPayload = {
+      sub: user.id,
+      userName: user.userName,
+      name: user.name,
+    };
     const accessToken = this.jwtService.sign(payload, {
       secret: this.configService.getOrThrow<string>('JWT_SECRET_KEY'),
       expiresIn: this.configService.getOrThrow<string>('JWT_ACCESS_EXPIRES_IN'),

--- a/src/comments/comment.swagger.ts
+++ b/src/comments/comment.swagger.ts
@@ -159,7 +159,7 @@ const successResponseNoData = (message: string, status = 200) =>
   });
 
 // 클라이언트 요청 오류 응답
-const badRequestException = () =>
+const badRequestResponse = () =>
   ApiResponse({
     status: 400,
     description: '잘못된 요청 데이터',
@@ -253,7 +253,7 @@ export const ApiComments = {
         201,
         '댓글이 성공적으로 생성되었습니다.',
       ),
-      badRequestException(),
+      badRequestResponse(),
       withUnauthorizedResponses(),
       withNotFoundResponses(['PostNotFound']),
     ),
@@ -320,7 +320,7 @@ export const ApiComments = {
               postId: 1,
               userId: 6,
               content: '다음에 만날까요?.',
-              parentId: 2,
+              parentId: 1,
               createdAt: '2025-07-02T10:05:00Z',
               updatedAt: null,
               user: {

--- a/src/comments/comment.swagger.ts
+++ b/src/comments/comment.swagger.ts
@@ -1,0 +1,337 @@
+import { applyDecorators, Type } from '@nestjs/common';
+import {
+  ApiExtraModels,
+  ApiOperation,
+  ApiQuery,
+  ApiResponse,
+  getSchemaPath,
+} from '@nestjs/swagger';
+import { ApiResponseDto } from './dto/api-response.dto';
+import { ResCommentDto } from './dto/res-comment.dto';
+
+// 공통 Unauthorized
+const unauthorizedExamples = {
+  TokenExpired: {
+    message: '토큰이 만료되었습니다. 다시 로그인해주세요.',
+    error: 'Unauthorized',
+    statusCode: 401,
+  },
+  InvalidToken: {
+    message: '유효하지 않은 토큰입니다.',
+    error: 'Unauthorized',
+    statusCode: 401,
+  },
+};
+
+// 공통 Not Found
+const notFoundExamples = {
+  PostNotFound: {
+    message: '존재하지 않는 게시글입니다.',
+    error: 'Not Found',
+    statusCode: 404,
+  },
+  CommentNotFound: {
+    message: '존재하지 않는 댓글입니다.',
+    error: 'Not Found',
+    statusCode: 404,
+  },
+};
+
+// 래핑 함수
+const withUnauthorizedResponses = () =>
+  unauthorizedResponses(unauthorizedExamples);
+
+const withNotFoundResponses = (keys: (keyof typeof notFoundExamples)[]) =>
+  NotFoundResponses(
+    keys.reduce(
+      (obj, key) => {
+        obj[key] = notFoundExamples[key];
+        return obj;
+      },
+      {} as Record<string, any>,
+    ),
+  );
+
+// 성공 응답
+const ApiResponseWithData = <T extends Type<any>>(
+  model: T,
+  status = 200,
+  description = '요청이 성공적으로 처리되었습니다.',
+) => {
+  return applyDecorators(
+    ApiExtraModels(ApiResponseDto, model),
+    ApiResponse({
+      status,
+      description,
+      schema: {
+        allOf: [
+          { $ref: getSchemaPath(ApiResponseDto) },
+          {
+            properties: {
+              data: { $ref: getSchemaPath(model) },
+            },
+          },
+        ],
+      },
+    }),
+  );
+};
+
+const ApiResponseWithArrayData = <T extends Type<any>>(
+  model: T,
+  status = 200,
+  description = '요청이 성공적으로 처리되었습니다.',
+  examples?: {
+    parentOnly?: any[];
+    childOnly?: any[];
+    empty?: any[];
+  },
+) => {
+  const exampleEntries: Record<string, { value: any }> = {};
+
+  if (examples?.parentOnly) {
+    exampleEntries['부모 댓글만 조회되는 경우 (parentId 쿼리 없음)'] = {
+      value: {
+        status: 'success',
+        message: description,
+        data: examples.parentOnly,
+      },
+    };
+  }
+  if (examples?.childOnly) {
+    exampleEntries['자식 댓글만 조회되는 경우 (parentId 쿼리 있음)'] = {
+      value: {
+        status: 'success',
+        message: description,
+        data: examples.childOnly,
+      },
+    };
+  }
+  if (examples?.empty) {
+    exampleEntries['댓글이 없을 경우'] = {
+      value: {
+        status: 'success',
+        message: description,
+        data: examples.empty,
+      },
+    };
+  }
+
+  return applyDecorators(
+    ApiExtraModels(ApiResponseDto, model),
+    ApiResponse({
+      status,
+      description,
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              status: { type: 'string', example: 'success' },
+              message: { type: 'string', example: description },
+              data: {
+                type: 'array',
+                items: { $ref: getSchemaPath(model) },
+              },
+            },
+          },
+          examples:
+            Object.keys(exampleEntries).length > 0 ? exampleEntries : undefined,
+        },
+      },
+    }),
+  );
+};
+
+const successResponseNoData = (message: string, status = 200) =>
+  ApiResponse({
+    status,
+    description: message,
+    content: {
+      'application/json': {
+        example: {
+          status: 'success',
+          message,
+          data: null,
+        },
+      },
+    },
+  });
+
+// 클라이언트 요청 오류 응답
+const badRequestException = () =>
+  ApiResponse({
+    status: 400,
+    description: '잘못된 요청 데이터',
+    content: {
+      'application/json': {
+        example: {
+          message: ['content must be a string', '댓글 내용은 필수입니다.'],
+          error: 'Bad Request',
+          statusCode: 400,
+        },
+      },
+    },
+  });
+
+const unauthorizedResponses = (examples: {
+  [key: string]: { message: string; error: string; statusCode: number };
+}) =>
+  ApiResponse({
+    status: 401,
+    description: '인증되지 않음 (JWT 토큰 없음 또는 유효하지 않음)',
+    content: {
+      'application/json': {
+        examples: Object.entries(examples).reduce(
+          (acc, [name, exValue]) => {
+            acc[name] = {
+              value: {
+                message: exValue.message,
+                error: exValue.error,
+                statusCode: exValue.statusCode,
+              },
+            };
+            return acc;
+          },
+          {} as { [key: string]: { value: any } },
+        ),
+      },
+    },
+  });
+
+// 인증 / 권한 관련 응답
+const forbiddenResponse = () =>
+  ApiResponse({
+    status: 403,
+    description: '권한 없음',
+    content: {
+      'application/json': {
+        example: {
+          message: '해당 댓글을 수정하거나 삭제할 권한이 없습니다.',
+          error: 'Forbidden',
+          statusCode: 403,
+        },
+      },
+    },
+  });
+
+// 리소스 없음
+const NotFoundResponses = (examples: {
+  [key: string]: { message: string; error: string; statusCode: number };
+}) =>
+  ApiResponse({
+    status: 404,
+    description: '요청한 리소스를 찾을 수 없음',
+    content: {
+      'application/json': {
+        examples: Object.entries(examples).reduce(
+          (acc, [name, exValue]) => {
+            acc[name] = {
+              value: {
+                message: exValue.message,
+                error: exValue.error,
+                statusCode: exValue.statusCode,
+              },
+            };
+            return acc;
+          },
+          {} as { [key: string]: { value: any } },
+        ),
+      },
+    },
+  });
+
+export const ApiComments = {
+  create: () =>
+    applyDecorators(
+      ApiOperation({
+        summary: '댓글 생성',
+        description: '게시글에 댓글을 생성합니다.',
+      }),
+      ApiResponseWithData(
+        ResCommentDto,
+        201,
+        '댓글이 성공적으로 생성되었습니다.',
+      ),
+      badRequestException(),
+      withUnauthorizedResponses(),
+      withNotFoundResponses(['PostNotFound']),
+    ),
+
+  update: () =>
+    applyDecorators(
+      ApiOperation({ summary: '댓글 수정', description: '댓글을 수정합니다.' }),
+      ApiResponseWithData(
+        ResCommentDto,
+        200,
+        '댓글이 성공적으로 수정되었습니다.',
+      ),
+      forbiddenResponse(),
+      withUnauthorizedResponses(),
+      withNotFoundResponses(['PostNotFound', 'CommentNotFound']),
+    ),
+
+  delete: () =>
+    applyDecorators(
+      ApiOperation({ summary: '댓글 삭제', description: '댓글을 삭제합니다.' }),
+      successResponseNoData('댓글이 성공적으로 삭제되었습니다.'),
+      forbiddenResponse(),
+      withUnauthorizedResponses(),
+      withNotFoundResponses(['PostNotFound', 'CommentNotFound']),
+    ),
+
+  getList: () =>
+    applyDecorators(
+      ApiOperation({
+        summary: '댓글 목록 조회',
+        description: `parentId 쿼리 파라미터 유무에 따라 결과가 다릅니다.\n
+        - parentId 없이 요청: 해당 게시글의 최상위 댓글 목록 조회
+        - ?parentId=3 등으로 요청: 해당 댓글 ID의 대댓글 목록 조회`,
+      }),
+      ApiQuery({
+        name: 'parentId',
+        description: '부모 댓글 ID (없을 경우 null)',
+        type: 'number',
+        required: false,
+        example: 1,
+      }),
+      ApiResponseWithArrayData(
+        ResCommentDto,
+        200,
+        '댓글이 성공적으로 조회되었습니다.',
+        {
+          parentOnly: [
+            {
+              id: 1,
+              postId: 1,
+              userId: 6,
+              content: '폭염 주의보래요.',
+              parentId: null,
+              createdAt: '2025-07-02T10:00:00Z',
+              updatedAt: null,
+              user: {
+                name: '김남주',
+              },
+            },
+          ],
+          childOnly: [
+            {
+              id: 2,
+              postId: 1,
+              userId: 6,
+              content: '다음에 만날까요?.',
+              parentId: 2,
+              createdAt: '2025-07-02T10:05:00Z',
+              updatedAt: null,
+              user: {
+                name: '김여주',
+              },
+            },
+          ],
+          empty: [],
+        },
+      ),
+      withUnauthorizedResponses(),
+      withNotFoundResponses(['PostNotFound']),
+    ),
+};

--- a/src/comments/comments.controller.ts
+++ b/src/comments/comments.controller.ts
@@ -11,18 +11,23 @@ import {
   Req,
   UseGuards,
 } from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { Request } from 'express';
 import { CustomJwtAuthGuard } from 'src/auth/guards/access.guard';
+import { ApiComments } from './comment.swagger';
 import { CommentsService } from './comments.service';
 import { CreateCommentDto } from './dto/create-comment.dto';
 import { UpdateCommentDto } from './dto/update-comment.dto';
 
+@ApiTags('Comments')
+@ApiBearerAuth('accessToken')
 @UseGuards(CustomJwtAuthGuard)
 @Controller('groups/:groupId/posts/:postId/comments')
 export class CommentsController {
   constructor(private readonly commentsService: CommentsService) {}
 
   @Post()
+  @ApiComments.create()
   async createComment(
     @Param('groupId', ParseIntPipe) groupId: number,
     @Param('postId', ParseIntPipe) postId: number,
@@ -45,6 +50,7 @@ export class CommentsController {
   }
 
   @Get()
+  @ApiComments.getList()
   async getCommentsByPost(
     @Param('groupId', ParseIntPipe) groupId: number,
     @Param('postId', ParseIntPipe) postId: number,
@@ -63,6 +69,7 @@ export class CommentsController {
   }
 
   @Patch(':id')
+  @ApiComments.update()
   async updateComment(
     @Param('groupId', ParseIntPipe) groupId: number,
     @Param('postId', ParseIntPipe) postId: number,
@@ -87,6 +94,7 @@ export class CommentsController {
   }
 
   @Delete(':id')
+  @ApiComments.delete()
   async deleteComment(
     @Param('groupId', ParseIntPipe) groupId: number,
     @Param('postId', ParseIntPipe) postId: number,

--- a/src/comments/comments.controller.ts
+++ b/src/comments/comments.controller.ts
@@ -20,7 +20,7 @@ import { CreateCommentDto } from './dto/create-comment.dto';
 import { UpdateCommentDto } from './dto/update-comment.dto';
 
 @ApiTags('Comments')
-@ApiBearerAuth('accessToken')
+@ApiBearerAuth('access-token')
 @UseGuards(CustomJwtAuthGuard)
 @Controller('groups/:groupId/posts/:postId/comments')
 export class CommentsController {

--- a/src/comments/dto/api-response.dto.ts
+++ b/src/comments/dto/api-response.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ApiResponseDto<T> {
+  @ApiProperty({
+    description: '요청 처리 상태 (예: success / fail)',
+  })
+  status: string;
+
+  @ApiProperty({
+    description: '응답 메시지',
+    example: '요청이 성공적으로 처리되었습니다.',
+  })
+  message: string;
+
+  @ApiProperty({
+    description: '응답 데이터',
+    nullable: true,
+  })
+  data: T;
+}

--- a/src/comments/dto/create-comment.dto.ts
+++ b/src/comments/dto/create-comment.dto.ts
@@ -1,12 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
 import { IsInt, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 export class CreateCommentDto {
+  @ApiProperty({
+    description: '댓글 내용',
+    example: '참석합니다!',
+    required: true,
+  })
   @IsNotEmpty({ message: '댓글 내용은 필수입니다.' })
   @IsString()
   @Transform(({ value }: { value: string }) => value.trim())
   content: string;
 
+  @ApiProperty({
+    description: '부모 댓글 ID (선택사항)',
+    example: 1,
+    required: false,
+    nullable: true,
+  })
   @IsOptional()
   @IsInt()
   parentId?: number | null;

--- a/src/comments/dto/query-comment.dto.ts
+++ b/src/comments/dto/query-comment.dto.ts
@@ -1,7 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { IsInt, IsOptional, Min } from 'class-validator';
 
 export class QueryCommentDto {
+  @ApiProperty({
+    description: '부모 댓글 ID로 필터링 (선택사항)',
+    example: 1,
+    required: false,
+    minimum: 1,
+  })
   @IsOptional()
   @Type(() => Number)
   @IsInt()

--- a/src/comments/dto/res-comment.dto.ts
+++ b/src/comments/dto/res-comment.dto.ts
@@ -1,0 +1,31 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ResCommentDto {
+  @ApiProperty({ description: '댓글 ID', example: 1 })
+  id: number;
+
+  @ApiProperty({ description: '댓글 내용', example: '새 댓글입니다.' })
+  content: string;
+
+  @ApiProperty({ description: '댓글 작성자 ID', example: 123 })
+  userId: number;
+
+  @ApiProperty({ description: '댓글이 속한 게시물 ID', example: 456 })
+  postId: number;
+
+  @ApiProperty({ description: '부모 댓글 ID (없을 경우 null)', example: null })
+  parentId: number | null;
+
+  @ApiProperty({
+    description: '댓글 생성 일자',
+    example: '2023-01-01T00:00:00.000Z',
+  })
+  createdAt: Date;
+
+  @ApiProperty({
+    description: '댓글 수정 일자 (수정되지 않았을 경우 null)',
+    example: 'null',
+    nullable: true,
+  })
+  updatedAt: Date | null;
+}

--- a/src/comments/dto/update-comment.dto.ts
+++ b/src/comments/dto/update-comment.dto.ts
@@ -1,7 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
 import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 export class UpdateCommentDto {
+  @ApiProperty({
+    description: '수정할 댓글 내용 (선택사항)',
+    example: '불참합니다!',
+    required: false,
+  })
   @IsOptional()
   @IsString()
   @IsNotEmpty({ message: '댓글 내용은 필수입니다.' })

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { ValidationPipe, ClassSerializerInterceptor } from '@nestjs/common';
+import { ClassSerializerInterceptor, ValidationPipe } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { NestFactory, Reflector } from '@nestjs/core';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
@@ -40,26 +40,19 @@ async function bootstrap() {
         scheme: 'bearer',
         bearerFormat: 'JWT',
         name: 'Authorization',
+        description: 'JWT 토큰을 입력하세요.',
         in: 'header',
       },
       'access-token',
     )
     .setTermsOfService('https://github.com/modern-agile-team/9term-main-back')
     .addTag('모동구')
-    .addBearerAuth(
-      {
-        type: 'http',
-        scheme: 'bearer',
-        bearerFormat: 'JWT',
-        name: 'Authorization',
-        description: 'JWT 토큰을 입력하세요.',
-        in: 'header',
-      },
-      'accessToken',
-    )
     .build();
 
-  const document = SwaggerModule.createDocument(app, config);
+  const document = SwaggerModule.createDocument(app, config, {
+    extraModels: [],
+    operationIdFactory: (controllerKey: string, methodKey: string) => methodKey,
+  });
   SwaggerModule.setup('api', app, document);
 
   await app.listen(process.env.PORT ?? 3000);

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,8 +2,8 @@ import { ValidationPipe, ClassSerializerInterceptor } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { NestFactory, Reflector } from '@nestjs/core';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
-import { AppModule } from './app.module';
 import * as cookieParser from 'cookie-parser';
+import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -46,6 +46,17 @@ async function bootstrap() {
     )
     .setTermsOfService('https://github.com/modern-agile-team/9term-main-back')
     .addTag('모동구')
+    .addBearerAuth(
+      {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+        name: 'Authorization',
+        description: 'JWT 토큰을 입력하세요.',
+        in: 'header',
+      },
+      'accessToken',
+    )
     .build();
 
   const document = SwaggerModule.createDocument(app, config);

--- a/src/posts/post.swagger.ts
+++ b/src/posts/post.swagger.ts
@@ -1,6 +1,5 @@
 import { applyDecorators, Type } from '@nestjs/common';
 import {
-  ApiBearerAuth,
   ApiExtraModels,
   ApiOperation,
   ApiResponse,
@@ -86,7 +85,6 @@ function ApiArrayResponseWithData<T extends Type<any>>(
 export const ApiPosts = {
   create: () =>
     applyDecorators(
-      ApiBearerAuth('access-token'),
       ApiOperation({ summary: '게시물 생성' }),
       ApiResponseWithData(
         ResPostDto,
@@ -111,7 +109,6 @@ export const ApiPosts = {
 
   getAll: () =>
     applyDecorators(
-      ApiBearerAuth('access-token'),
       ApiOperation({ summary: '모든 게시물 조회' }),
       ApiArrayResponseWithData(
         ResPostDto,
@@ -123,7 +120,6 @@ export const ApiPosts = {
 
   getOne: () =>
     applyDecorators(
-      ApiBearerAuth('access-token'),
       ApiOperation({ summary: '특정 게시물 조회' }),
       ApiResponseWithData(ResPostDto, 200, '게시물을 성공적으로 가져왔습니다.'),
       ApiResponse({
@@ -144,7 +140,6 @@ export const ApiPosts = {
 
   update: () =>
     applyDecorators(
-      ApiBearerAuth('access-token'),
       ApiOperation({ summary: '게시물 수정' }),
       ApiResponseWithData(
         ResPostDto,
@@ -169,7 +164,6 @@ export const ApiPosts = {
 
   delete: () =>
     applyDecorators(
-      ApiBearerAuth('access-token'),
       ApiOperation({ summary: '게시물 삭제' }),
       ApiResponse({
         status: 200,

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -10,6 +10,7 @@ import {
   Req,
   UseGuards,
 } from '@nestjs/common';
+import { ApiBearerAuth } from '@nestjs/swagger';
 import { Request } from 'express';
 import { CustomJwtAuthGuard } from 'src/auth/guards/access.guard';
 import { AuthenticatedUserResponse } from 'src/auth/interfaces/authenticated-user-response.interface';
@@ -22,6 +23,7 @@ interface AuthenticatedRequest extends Request {
   user: AuthenticatedUserResponse;
 }
 
+@ApiBearerAuth('access-token')
 @Controller('groups/:groupId/posts')
 @UseGuards(CustomJwtAuthGuard)
 export class PostsController {


### PR DESCRIPTION
관련 이슈
-
- #45 

📝 제목
-
[docs] 댓글 API Swagger 문서화

📋 작업 내용
-
- [x] 댓글 생성/수정/삭제/조회 API에 Swagger 데코레이터 적용
- [x] 댓글 응답 DTO(ResCommentDto) 작성 및 Swagger 속성 상세 정의
- [x] ApiResponseDto 기반 공통 응답 형식 도입
- [x] 공통 응답 포맷 유틸 함수(comment.swagger.ts) 분리로 재사용성 향상 

🔧 기술 변경
-
- comment.swagger.ts 파일 및 ResCommentDto 추가
- Swagger 관련 데코레이터 및 유틸 함수 구현
- API 응답 형식 개선을 위한 유틸 함수 분리

🚀 테스트 사항(선택)
-
- Swagger UI에서 댓글 API 문서 정상 노출 확인
- 다양한 요청 및 응답 시나리오에 따른 문서 동작 검증 (토큰 인증 관련 검증 진행 중)
- 예시 데이터 정상 표시 확인

## 💬 리뷰 요구사항 (선택)  
- Swagger 문서에 누락된 부분 없는지 확인 부탁드립니다.
- 공통 응답 구조와 예시 데이터 적절성에 대한 피드백 요청드립니다.
