### PR TITLE
fix: (#59) CI/CD 설정에 .env 파일 추가

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,6 +76,7 @@ jobs:
             -p $APP_PORT:$CONTAINER_PORT \
             -v $HOME/9term-main-back/certbot/www:/var/www/certbot \
             -v $HOME/9term-main-back/certbot/conf:/etc/letsencrypt \
+            --env-file /home/ubuntu/9term-main-back/.env \
             $DOCKER_IMAGE_NAME:latest
 
           echo "Docker 컨테이너가 성공적으로 시작되었습니다."


### PR DESCRIPTION
관련 이슈
-
- #59 

📝 제목
-
 CI/CD 설정에 .env 파일 추가

📋 작업 내용
-
- [x]  CI/CD 워크플로우에서 .env 파일을 사용하도록 설정 (docker run 명령어에 --env-file 옵션 추가)

🔧 기술 변경
-
-  .github/workflows/main.yml 파일 수정
docker run 명령에 --env-file 옵션을 추가하여 
EC2 호스트의 .env 파일에 정의된 환경 변수들이 컨테이너로 올바르게 주입되도록 변경 

