### PR TITLE
feat: (#74) 게시물 좋아요 API 구현 및 Swagger 문서화

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,10 +5,11 @@ import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
 import { UserController } from './auth/user.controller';
 import { CommentsModule } from './comments/comments.module';
+import { GroupsModule } from './groups/groups.module';
+import { PostLikesModule } from './likes/postlikes.module';
+import { MemberModule } from './member/member.module';
 import { PostsModule } from './posts/posts.module';
 import { PrismaModule } from './prisma/prisma.module';
-import { MemberModule } from './member/member.module';
-import { GroupsModule } from './groups/groups.module';
 import { S3Module } from './s3/s3.module';
 
 @Module({
@@ -20,6 +21,7 @@ import { S3Module } from './s3/s3.module';
     CommentsModule,
     S3Module,
     GroupsModule,
+    PostLikesModule,
     ConfigModule.forRoot({
       isGlobal: true,
     }),

--- a/src/auth/user.decorator.ts
+++ b/src/auth/user.decorator.ts
@@ -1,0 +1,9 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { AuthenticatedUser } from './interfaces/authenticated-user.interface';
+export const User = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext): AuthenticatedUser => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const request = ctx.switchToHttp().getRequest();
+    return request.user as AuthenticatedUser;
+  },
+);

--- a/src/common/dto/api-response.dto.ts
+++ b/src/common/dto/api-response.dto.ts
@@ -8,7 +8,7 @@ export class ApiResponseDto<T = any> {
     example: '요청이 성공적으로 처리되었습니다.',
     description: '응답 메시지',
   })
-  message: string;
+  message?: string;
 
   @ApiProperty({
     description: '응답 데이터',

--- a/src/likes/interfaces/postlikes.interface.ts
+++ b/src/likes/interfaces/postlikes.interface.ts
@@ -1,0 +1,3 @@
+export interface ToggleLikeResult {
+  isLiked: boolean;
+}

--- a/src/likes/postlikes.controller.ts
+++ b/src/likes/postlikes.controller.ts
@@ -1,0 +1,33 @@
+import {
+  Controller,
+  Param,
+  ParseIntPipe,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { CustomJwtAuthGuard } from 'src/auth/guards/access.guard';
+import { AuthenticatedUser } from 'src/auth/interfaces/authenticated-user.interface';
+import { User } from 'src/auth/user.decorator';
+import { ApiResponseDto } from 'src/common/dto/api-response.dto';
+import { ToggleLikeResult } from 'src/likes/interfaces/postlikes.interface';
+import { PostLikesService } from 'src/likes/postlikes.service';
+import { ApiLikes } from './postlikes.swagger';
+
+@ApiTags('PostLikes')
+@ApiBearerAuth('access-token')
+@UseGuards(CustomJwtAuthGuard)
+@Controller('/groups/:groupId/posts/:postId')
+export class PostLikesController {
+  constructor(private readonly postLikesService: PostLikesService) {}
+
+  @Post('/likes')
+  @ApiLikes.toggleLike()
+  async toggleLike(
+    @Param('groupId', ParseIntPipe) groupId: number,
+    @Param('postId', ParseIntPipe) postId: number,
+    @User() user: AuthenticatedUser,
+  ): Promise<ApiResponseDto<ToggleLikeResult>> {
+    return this.postLikesService.toggleLike(groupId, postId, user.userId);
+  }
+}

--- a/src/likes/postlikes.module.ts
+++ b/src/likes/postlikes.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { PostLikesController } from './postlikes.controller';
+import { PostLikesRepository } from './postlikes.repository';
+import { PostLikesService } from './postlikes.service';
+
+@Module({
+  controllers: [PostLikesController],
+  providers: [PostLikesRepository, PostLikesService],
+})
+export class PostLikesModule {}

--- a/src/likes/postlikes.repository.ts
+++ b/src/likes/postlikes.repository.ts
@@ -1,0 +1,80 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { Group, Post, PostLike, Prisma } from '@prisma/client';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+type TxClient = Prisma.TransactionClient;
+
+@Injectable()
+export class PostLikesRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  private getClient(tx?: TxClient) {
+    return tx ?? this.prisma;
+  }
+
+  // 그룹 조회 메서드
+  async findGroupByIdOrThrow(groupId: number, tx?: TxClient): Promise<Group> {
+    const group = await this.getClient(tx).group.findUnique({
+      where: { id: groupId },
+    });
+    if (!group) {
+      throw new NotFoundException(`ID가 ${groupId}인 그룹을 찾을 수 없습니다.`);
+    }
+    return group;
+  }
+
+  // 게시물 조회 메서드
+  async findPostByIdOrThrow(postId: number, tx?: TxClient): Promise<Post> {
+    const post = await this.getClient(tx).post.findUnique({
+      where: { id: postId },
+    });
+    if (!post) {
+      throw new NotFoundException(
+        `ID가 ${postId}인 게시물을 찾을 수 없습니다.`,
+      );
+    }
+    return post;
+  }
+
+  // 좋아요 기록 조회 메서드
+  async findPostLike(
+    userId: number,
+    postId: number,
+    tx?: TxClient,
+  ): Promise<PostLike | null> {
+    return this.getClient(tx).postLike.findUnique({
+      where: {
+        postId_userId: {
+          userId: userId,
+          postId: postId,
+        },
+      },
+    });
+  }
+
+  // 좋아요 기록 생성 메서드
+  async createPostLike(
+    userId: number,
+    postId: number,
+    tx: TxClient,
+  ): Promise<PostLike> {
+    return tx.postLike.create({
+      data: { userId, postId },
+    });
+  }
+
+  // 좋아요 기록 삭제 메서드
+  async deletePostLike(postLikeId: number, tx: TxClient): Promise<void> {
+    await tx.postLike.delete({
+      where: { id: postLikeId },
+    });
+  }
+
+  // 게시물 좋아요 개수 조회
+  async getPostLikeCount(postId: number): Promise<number> {
+    const count = await this.prisma.postLike.count({
+      where: { postId: postId },
+    });
+    return count;
+  }
+}

--- a/src/likes/postlikes.service.ts
+++ b/src/likes/postlikes.service.ts
@@ -1,0 +1,73 @@
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { ApiResponseDto } from '../common/dto/api-response.dto';
+import { ToggleLikeResult } from './interfaces/postlikes.interface';
+import { PostLikesRepository } from './postlikes.repository';
+
+type PrismaTransactionClient = Prisma.TransactionClient;
+
+@Injectable()
+export class PostLikesService {
+  constructor(
+    private readonly postLikesRepository: PostLikesRepository,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  async toggleLike(
+    groupId: number,
+    postId: number,
+    userId: number,
+  ): Promise<ApiResponseDto<ToggleLikeResult>> {
+    return this.prisma.$transaction(async (tx: PrismaTransactionClient) => {
+      await this.postLikesRepository.findGroupByIdOrThrow(groupId, tx);
+      const post = await this.postLikesRepository.findPostByIdOrThrow(
+        postId,
+        tx,
+      );
+
+      if (post.groupId !== groupId) {
+        throw new NotFoundException(
+          `ID가 ${postId}인 게시물은 ID가 ${groupId}인 그룹에 속한 게시물이 아닙니다.`,
+        );
+      }
+
+      // 기존 좋아요 기록이 있는지 확인
+      const existingLike = await this.postLikesRepository.findPostLike(
+        userId,
+        postId,
+        tx,
+      );
+
+      let isLiked: boolean;
+
+      if (existingLike) {
+        // 좋아요 취소: 기록 삭제
+        await this.postLikesRepository.deletePostLike(existingLike.id, tx);
+        isLiked = false;
+      } else {
+        try {
+          // 좋아요 추가: 새 기록 생성
+          await this.postLikesRepository.createPostLike(userId, postId, tx);
+          isLiked = true;
+        } catch (error) {
+          if (
+            error instanceof Prisma.PrismaClientKnownRequestError &&
+            error.code === 'P2002'
+          ) {
+            throw new ConflictException('이미 좋아요를 누른 게시물입니다.');
+          }
+          throw error;
+        }
+      }
+      return {
+        status: 'success',
+        data: { isLiked },
+      };
+    });
+  }
+}

--- a/src/likes/postlikes.swagger.ts
+++ b/src/likes/postlikes.swagger.ts
@@ -1,0 +1,108 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+
+const UnauthorizedExamples = () =>
+  ApiResponse({
+    status: 401,
+    description: '인증되지 않은 사용자',
+    content: {
+      'application/json': {
+        examples: {
+          TokenExpired: {
+            value: {
+              message: '토큰이 만료되었습니다. 다시 로그인해주세요.',
+              error: 'Unauthorized',
+              statusCode: 401,
+            },
+          },
+          InvalidToken: {
+            value: {
+              message: '유효하지 않은 토큰입니다.',
+              error: 'Unauthorized',
+              statusCode: 401,
+            },
+          },
+        },
+      },
+    },
+  });
+
+const NotFoundExamples = () =>
+  ApiResponse({
+    status: 404,
+    description: '그룹 또는 게시물이 존재하지 않음',
+    content: {
+      'application/json': {
+        examples: {
+          GroupNotFound: {
+            summary: 'GroupNotFound',
+            value: {
+              message: '존재하지 않는 그룹입니다.',
+              error: 'Not Found',
+              statusCode: 404,
+            },
+          },
+          PostNotFound: {
+            summary: 'PostNotFound',
+            value: {
+              message: '존재하지 않는 게시물입니다.',
+              error: 'Not Found',
+              statusCode: 404,
+            },
+          },
+          PostGroupMismatch: {
+            summary: 'PostGroupMismatch',
+            value: {
+              message:
+                'ID가 {postId}인 게시물은 ID가 {groupId}인 그룹에 속한 게시물이 아닙니다.',
+              error: 'Not Found',
+              statusCode: 404,
+            },
+          },
+        },
+      },
+    },
+  });
+
+const ToggleLikeResponses = () =>
+  ApiResponse({
+    status: 200,
+    description: '좋아요 토글 처리 완료',
+    content: {
+      'application/json': {
+        examples: {
+          Liked: {
+            summary: 'Liked',
+            value: {
+              status: 'success',
+              data: {
+                isLiked: true,
+              },
+            },
+          },
+          Unliked: {
+            summary: 'LikeRemoved',
+            value: {
+              status: 'success',
+              data: {
+                isLiked: false,
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+
+export const ApiLikes = {
+  toggleLike: () =>
+    applyDecorators(
+      ApiOperation({
+        summary: '게시물 좋아요',
+        description: '게시물에 좋아요를 누르거나 취소합니다.',
+      }),
+      ToggleLikeResponses(),
+      NotFoundExamples(),
+      UnauthorizedExamples(),
+    ),
+};


### PR DESCRIPTION
관련 이슈
-
- #74

📝 제목
-
[Feature] 게시물 좋아요 API 구현 및 Swagger 문서화

📋 작업 내용
-
- [x]  게시물 좋아요 기능 토글 방식으로 구현 (등록/취소)
- [x]  Prisma P2002 예외로 중복 좋아요 처리
- [x]  Swagger 문서 작성 (성공/에러 응답 명시)
- [x]  `@User` 커스텀 데코레이터 적용 
- [x]  api-response.dto.ts의 message 필드를 옵셔널로 변경

🔧 기술 변경
-
 AppModule에 PostLikesModule 추가
 Swagger 문서 분리 작성 (`postlikes.swagger.ts`)

🚀 테스트 사항(선택)
-
 Swagger 문서를 통한 API 테스트 완료
콘솔 로그를 통한 커스텀 데코레이터 `@User` 작동 확인
