### PR TITLE
feat: (#77) 그룹 이미지 관련 S3를 통한 이미지 업로드 및 삭제 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1818,9 +1818,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.3.tgz",
-      "integrity": "sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.4.tgz",
+      "integrity": "sha512-Ul5l+lHEcw3L5+k8POx6r74mxEYKG5kOb6Xpy2gCRW6zweT6TEhAf8vhxGgjhqrd/VO/Dirhsb+1hNpD1ue9hw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3532,14 +3532,14 @@
       }
     },
     "node_modules/@nestjs/platform-express": {
-      "version": "11.1.4",
-      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.4.tgz",
-      "integrity": "sha512-SDpfSDJogCZ3fOeP518+GdjKnpJc51LN0dylapq3xBfxJeiEOqmqiZM1tWMOsoijPlUVsz0acpmaVEaOiMXpXw==",
+      "version": "11.1.5",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.5.tgz",
+      "integrity": "sha512-OsoiUBY9Shs5IG3uvDIt9/IDfY5OlvWBESuB/K4Eun8xILw1EK5d5qMfC3d2sIJ+kA3l+kBR1d/RuzH7VprLIg==",
       "license": "MIT",
       "dependencies": {
         "cors": "2.8.5",
         "express": "5.1.0",
-        "multer": "2.0.1",
+        "multer": "2.0.2",
         "path-to-regexp": "8.2.0",
         "tslib": "2.8.1"
       },
@@ -8815,9 +8815,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10936,9 +10936,9 @@
       "license": "MIT"
     },
     "node_modules/multer": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.1.tgz",
-      "integrity": "sha512-Ug8bXeTIUlxurg8xLTEskKShvcKDZALo1THEX5E41pYCD2sCVub5/kIRIGqWNoqV6szyLyQKV6mD4QUrWE5GCQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.2.tgz",
+      "integrity": "sha512-u7f2xaZ/UG8oLXHvtF/oWTRvT44p9ecwBBqTwgJVq0+4BW1g8OW01TyMEGWBHbyMOYVHXslaut7qEQ1meATXgw==",
       "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",

--- a/prisma/migrations/20250730070646_add_group_enums_and_img_path/migration.sql
+++ b/prisma/migrations/20250730070646_add_group_enums_and_img_path/migration.sql
@@ -1,48 +1,74 @@
-/*
-  Warnings:
+-- ========= Enums (존재하지 않으면 생성) =========
+DO $$ BEGIN
+  CREATE TYPE "UserGroupRole" AS ENUM ('MEMBER', 'MANAGER');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
 
-  - You are about to drop the column `post_img_url` on the `post_images` table. All the data in the column will be lost.
-  - The `role` column on the `user_groups` table would be dropped and recreated. This will lead to data loss if there is data in the column.
-  - A unique constraint covering the columns `[post_img_path]` on the table `post_images` will be added. If there are existing duplicate values, this will fail.
-  - Added the required column `post_img_path` to the `post_images` table without a default value. This is not possible if the table is not empty.
+DO $$ BEGIN
+  CREATE TYPE "MembershipStatus" AS ENUM ('PENDING', 'APPROVED', 'REJECTED', 'LEFT');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
 
-*/
--- CreateEnum
-CREATE TYPE "UserGroupRole" AS ENUM ('MEMBER', 'MANAGER');
+-- ========= groups: group_img_path 추가 =========
+ALTER TABLE "groups"
+  ADD COLUMN IF NOT EXISTS "group_img_path" VARCHAR(255);
 
--- CreateEnum
-CREATE TYPE "MembershipStatus" AS ENUM ('PENDING', 'APPROVED', 'REJECTED', 'LEFT');
+-- ========= post_images: (키만 저장 → 단순 복사) 안전 전환 =========
 
--- DropIndex
-DROP INDEX "post_images_post_img_url_key";
+-- 1) 우선 NULL 허용으로 추가 (이미 있으면 생략)
+ALTER TABLE "post_images"
+  ADD COLUMN IF NOT EXISTS "post_img_path" VARCHAR(255);
 
--- AlterTable
-ALTER TABLE "groups" ADD COLUMN     "group_img_path" VARCHAR(255);
+-- 2) 값 이관: 기존에도 "키"만 저장했다면 그대로 복사
+UPDATE "post_images"
+SET "post_img_path" = "post_img_url"
+WHERE "post_img_path" IS NULL
+  AND "post_img_url" IS NOT NULL;
 
--- AlterTable
-ALTER TABLE "post_images" DROP COLUMN "post_img_url",
-ADD COLUMN     "post_img_path" VARCHAR(255) NOT NULL;
+-- 3) UNIQUE 인덱스(중복 있으면 실패) - 우선 시도
+CREATE UNIQUE INDEX IF NOT EXISTS "post_images_post_img_path_key"
+  ON "post_images"("post_img_path");
 
--- AlterTable
-ALTER TABLE "user_groups" ADD COLUMN     "left_at" TIMESTAMP(3),
-ADD COLUMN     "status" "MembershipStatus" NOT NULL DEFAULT 'PENDING',
-DROP COLUMN "role",
-ADD COLUMN     "role" "UserGroupRole" NOT NULL DEFAULT 'MEMBER';
+-- 4) 이제 NOT NULL 제약 강화
+ALTER TABLE "post_images"
+  ALTER COLUMN "post_img_path" SET NOT NULL;
 
--- CreateIndex
-CREATE UNIQUE INDEX "post_images_post_img_path_key" ON "post_images"("post_img_path");
+-- 5) URL 컬럼/인덱스 제거
+DROP INDEX IF EXISTS "post_images_post_img_url_key";
+ALTER TABLE "post_images"
+  DROP COLUMN IF EXISTS "post_img_url";
 
--- CreateIndex
-CREATE INDEX "post_likes_post_id_idx" ON "post_likes"("post_id");
+-- ========= user_groups: status/left_at/role(enum) =========
 
--- CreateIndex
-CREATE INDEX "user_groups_group_id_status_idx" ON "user_groups"("group_id", "status");
+-- 1) left_at / status 추가
+ALTER TABLE "user_groups"
+  ADD COLUMN IF NOT EXISTS "left_at" TIMESTAMP(3);
 
--- CreateIndex
-CREATE INDEX "user_groups_user_id_status_idx" ON "user_groups"("user_id", "status");
+ALTER TABLE "user_groups"
+  ADD COLUMN IF NOT EXISTS "status" "MembershipStatus" NOT NULL DEFAULT 'PENDING';
 
--- CreateIndex
-CREATE INDEX "user_groups_group_id_idx" ON "user_groups"("group_id");
+-- 2) role을 enum으로 전환(기존 값 보존)
+--    임시 enum 컬럼 추가
+ALTER TABLE "user_groups"
+  ADD COLUMN IF NOT EXISTS "role_tmp" "UserGroupRole" NOT NULL DEFAULT 'MEMBER';
 
--- CreateIndex
-CREATE INDEX "user_groups_user_id_idx" ON "user_groups"("user_id");
+--    기존 role 값을 enum으로 매핑 (기존 타입이 text/enum 무엇이든 문자열 비교)
+UPDATE "user_groups"
+SET "role_tmp" = CASE
+  WHEN LOWER(CAST("role" AS TEXT)) = 'manager' THEN 'MANAGER'::"UserGroupRole"
+  ELSE 'MEMBER'::"UserGroupRole"
+END
+WHERE "role" IS NOT NULL;
+
+--    기존 role 컬럼 제거 후 임시 컬럼을 role로 교체
+ALTER TABLE "user_groups" DROP COLUMN IF EXISTS "role";
+ALTER TABLE "user_groups" RENAME COLUMN "role_tmp" TO "role";
+
+-- ========= 인덱스들 =========
+CREATE INDEX IF NOT EXISTS "post_likes_post_id_idx" ON "post_likes"("post_id");
+CREATE INDEX IF NOT EXISTS "user_groups_group_id_status_idx" ON "user_groups"("group_id", "status");
+CREATE INDEX IF NOT EXISTS "user_groups_user_id_status_idx" ON "user_groups"("user_id", "status");
+CREATE INDEX IF NOT EXISTS "user_groups_group_id_idx" ON "user_groups"("group_id");
+CREATE INDEX IF NOT EXISTS "user_groups_user_id_idx" ON "user_groups"("user_id");

--- a/prisma/migrations/20250730070646_add_group_enums_and_img_path/migration.sql
+++ b/prisma/migrations/20250730070646_add_group_enums_and_img_path/migration.sql
@@ -1,0 +1,48 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `post_img_url` on the `post_images` table. All the data in the column will be lost.
+  - The `role` column on the `user_groups` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - A unique constraint covering the columns `[post_img_path]` on the table `post_images` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `post_img_path` to the `post_images` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateEnum
+CREATE TYPE "UserGroupRole" AS ENUM ('MEMBER', 'MANAGER');
+
+-- CreateEnum
+CREATE TYPE "MembershipStatus" AS ENUM ('PENDING', 'APPROVED', 'REJECTED', 'LEFT');
+
+-- DropIndex
+DROP INDEX "post_images_post_img_url_key";
+
+-- AlterTable
+ALTER TABLE "groups" ADD COLUMN     "group_img_path" VARCHAR(255);
+
+-- AlterTable
+ALTER TABLE "post_images" DROP COLUMN "post_img_url",
+ADD COLUMN     "post_img_path" VARCHAR(255) NOT NULL;
+
+-- AlterTable
+ALTER TABLE "user_groups" ADD COLUMN     "left_at" TIMESTAMP(3),
+ADD COLUMN     "status" "MembershipStatus" NOT NULL DEFAULT 'PENDING',
+DROP COLUMN "role",
+ADD COLUMN     "role" "UserGroupRole" NOT NULL DEFAULT 'MEMBER';
+
+-- CreateIndex
+CREATE UNIQUE INDEX "post_images_post_img_path_key" ON "post_images"("post_img_path");
+
+-- CreateIndex
+CREATE INDEX "post_likes_post_id_idx" ON "post_likes"("post_id");
+
+-- CreateIndex
+CREATE INDEX "user_groups_group_id_status_idx" ON "user_groups"("group_id", "status");
+
+-- CreateIndex
+CREATE INDEX "user_groups_user_id_status_idx" ON "user_groups"("user_id", "status");
+
+-- CreateIndex
+CREATE INDEX "user_groups_group_id_idx" ON "user_groups"("group_id");
+
+-- CreateIndex
+CREATE INDEX "user_groups_user_id_idx" ON "user_groups"("user_id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,9 +1,3 @@
-// This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
-
-// Looking for ways to speed up your queries, or scale easily with your serverless or edge functions?
-// Try Prisma Accelerate: https://pris.ly/cli/accelerate-init
-
 generator client {
   provider = "prisma-client-js"
 }
@@ -13,6 +7,7 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+//// ===== Enums =====
 enum UserGroupRole {
   MEMBER
   MANAGER
@@ -25,58 +20,47 @@ enum MembershipStatus {
   LEFT
 }
 
+//// ===== Models =====
 model User {
-  id         Int      @id @default(autoincrement())
-  username   String   @map("user_name") @db.VarChar(20) // 로그인 시 아이디
-  password   String   @db.VarChar(60)
-  name       String   @db.VarChar(50) // 사용자 이름
-  createdAt  DateTime @default(now()) @map("created_at")
+  id         Int         @id @default(autoincrement())
+  username   String      @unique @map("user_name") @db.VarChar(20)
+  password   String      @db.VarChar(60)
+  name       String      @db.VarChar(50)
+  createdAt  DateTime    @default(now()) @map("created_at")
+  comments   Comment[]
+  postLikes  PostLike[]
+  posts      Post[]
+  userGroups UserGroup[]
 
-  comments              Comment[]
-  postLikes             PostLike[]
-  posts                 Post[]
-  userGroups            UserGroup[]
-
-  @@unique([username])
   @@map("users")
 }
 
 model Group {
-  id          Int      @id @default(autoincrement())
-  name        String   @db.VarChar(100)
-  description String?
-  groupImgPath String?  @map("group_img_path") @db.VarChar(255)
-  createdAt   DateTime @default(now()) @map("created_at")
-
-  posts         Post[]
-  userGroups    UserGroup[]
+  id           Int         @id @default(autoincrement())
+  name         String      @db.VarChar(100)
+  description  String?
+  createdAt    DateTime    @default(now()) @map("created_at")
+  groupImgPath String?     @map("group_img_path")        // ← 추가
+  posts        Post[]
+  userGroups   UserGroup[]
 
   @@map("groups")
 }
 
 model UserGroup {
-  id        Int              @id @default(autoincrement())
-  userId    Int              @map("user_id")
-  groupId   Int              @map("group_id")
-  role      UserGroupRole    @default(MEMBER)
-  status    MembershipStatus @default(PENDING)
-  leftAt    DateTime?        @map("left_at")
-  createdAt DateTime         @default(now()) @map("created_at")
+  id        Int               @id @default(autoincrement())
+  userId    Int               @map("user_id")
+  groupId   Int               @map("group_id")
+  role      UserGroupRole                                 // ← String → enum
+  status    MembershipStatus   @default(PENDING)          // ← 추가
+  leftAt    DateTime?          @map("left_at")            // ← 추가
+  createdAt DateTime           @default(now()) @map("created_at")
 
-  group Group @relation(fields: [groupId], references: [id], onDelete: Cascade)
-  user  User  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  group     Group    @relation(fields: [groupId], references: [id], onDelete: Cascade)
+  user     User      @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([userId, groupId])
-  @@index([groupId, status]) // 특정 그룹의 멤버 상태별 조회 (예: 가입 대기 멤버)
-  @@index([userId, status])  // 특정 유저의 가입 그룹 상태별 조회 (예: 유저가 가입 대기 중인 그룹)
-  @@index([groupId]) // 특정 그룹의 모든 멤버를 조회할 때 (status 필터링 없이)
-  @@index([userId])  // 특정 유저가 속한 모든 그룹을 조회할 때 (status 필터링 없이)
   @@map("user_groups")
-}
-
-enum PostCategory {
-  NORMAL
-  ANNOUNCEMENT
 }
 
 model Post {
@@ -85,43 +69,38 @@ model Post {
   groupId    Int          @map("group_id")
   title      String       @db.VarChar(255)
   content    String
-  category   PostCategory @default(NORMAL)
   createdAt  DateTime     @default(now()) @map("created_at")
   updatedAt  DateTime?    @map("updated_at")
-
-  comments      Comment[]
-  postLikes     PostLike[]
-  postImages    PostImage[]
-
-  group Group @relation(fields: [groupId], references: [id], onDelete: Cascade)
-  user  User  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  category   PostCategory @default(NORMAL)
+  comments   Comment[]
+  postImages PostImage[]
+  postLikes  PostLike[]
+  group      Group        @relation(fields: [groupId], references: [id], onDelete: Cascade)
+  user       User         @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([groupId, createdAt])
   @@map("posts")
 }
 
 model PostImage {
-  id         Int      @id @default(autoincrement())
-  postId     Int      @map("post_id")
-  postImgPath String   @map("post_img_path") @db.VarChar(255)
-  createdAt  DateTime @default(now()) @map("created_at")
+  id          Int       @id @default(autoincrement())
+  postId      Int       @map("post_id")
+  postImgPath String    @unique @map("post_img_path")   // ← url → path 필드 교체
+  createdAt   DateTime  @default(now()) @map("created_at")
 
-  post Post @relation(fields: [postId], references: [id], onDelete: Cascade)
+  post        Post      @relation(fields: [postId], references: [id], onDelete: Cascade)
 
-  @@unique([postImgPath])
   @@map("post_images")
 }
 
 model PostLike {
-  id     Int @id @default(autoincrement())
-  postId Int @map("post_id")
-  userId Int @map("user_id")
-
-  post Post @relation(fields: [postId], references: [id], onDelete: Cascade)
-  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id     Int  @id @default(autoincrement())
+  postId Int  @map("post_id")
+  userId Int  @map("user_id")
+  post   Post @relation(fields: [postId], references: [id], onDelete: Cascade)
+  user   User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([postId, userId])
-  @@index([postId])
   @@map("post_likes")
 }
 
@@ -133,13 +112,17 @@ model Comment {
   parentId  Int?      @map("parent_id")
   createdAt DateTime  @default(now()) @map("created_at")
   updatedAt DateTime? @map("updated_at")
-
-  parent   Comment?  @relation("replies", fields: [parentId], references: [id], onDelete: Cascade)
-  children Comment[] @relation("replies")
-  post     Post      @relation(fields: [postId], references: [id], onDelete: Cascade)
-  user     User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  parent    Comment?  @relation("replies", fields: [parentId], references: [id], onDelete: Cascade)
+  children  Comment[] @relation("replies")
+  post      Post      @relation(fields: [postId], references: [id], onDelete: Cascade)
+  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([postId])
   @@index([parentId])
   @@map("comments")
+}
+
+enum PostCategory {
+  NORMAL
+  ANNOUNCEMENT
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -45,7 +45,7 @@ model Group {
   id          Int      @id @default(autoincrement())
   name        String   @db.VarChar(100)
   description String?
-  groupImgUrl String?  @map("group_img_url") @db.VarChar(255)
+  groupImgPath String?  @map("group_img_path") @db.VarChar(255)
   createdAt   DateTime @default(now()) @map("created_at")
 
   posts         Post[]
@@ -103,7 +103,7 @@ model Post {
 model PostImage {
   id         Int      @id @default(autoincrement())
   postId     Int      @map("post_id")
-  postImgPath String   @map("post_img_url") @db.VarChar(255)
+  postImgPath String   @map("post_img_path") @db.VarChar(255)
   createdAt  DateTime @default(now()) @map("created_at")
 
   post Post @relation(fields: [postId], references: [id], onDelete: Cascade)

--- a/src/groups/dto/create-group-image.dto.ts
+++ b/src/groups/dto/create-group-image.dto.ts
@@ -1,0 +1,9 @@
+import { Expose } from 'class-transformer';
+
+export class CreateGroupImageDto {
+  @Expose()
+  imageKey!: string;
+
+  @Expose()
+  imageUrl!: string;
+}

--- a/src/groups/dto/group-join-status.dto.ts
+++ b/src/groups/dto/group-join-status.dto.ts
@@ -16,4 +16,7 @@ export class GroupJoinStatusDto {
   })
   @Expose()
   role: 'admin' | 'member' | null;
+
+  @Expose()
+  groupImageUrl: string;
 }

--- a/src/groups/dto/group-with-member-count.dto.ts
+++ b/src/groups/dto/group-with-member-count.dto.ts
@@ -9,4 +9,7 @@ export class GroupWithMemberCountDto extends GroupResponseDto {
   })
   @Expose()
   memberCount: number;
+
+  @Expose()
+  groupImageUrl: string;
 }

--- a/src/groups/groups.module.ts
+++ b/src/groups/groups.module.ts
@@ -4,9 +4,10 @@ import { GroupsController } from './groups.controller';
 import { GroupsRepository } from './groups.repository';
 import { MembersService } from '../member/member.service';
 import { MemberModule } from '../member/member.module';
+import { S3Module } from 'src/s3/s3.module';
 
 @Module({
-  imports: [MemberModule],
+  imports: [MemberModule, S3Module],
   controllers: [GroupsController],
   providers: [GroupsService, GroupsRepository, MembersService],
 })

--- a/src/groups/groups.repository.ts
+++ b/src/groups/groups.repository.ts
@@ -1,3 +1,4 @@
+// src/groups/groups.repository.ts
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
 import {
@@ -21,6 +22,7 @@ export class GroupsRepository {
         data: {
           name: data.name,
           description: data.description,
+          groupImgPath: data.groupImagePath,
         },
       });
 
@@ -36,28 +38,25 @@ export class GroupsRepository {
     });
   }
 
-  findAllGroups(): Promise<Group[]> {
+  findAllGroups(): Promise<(Group & { _count: { userGroups: number } })[]> {
     return this.prisma.group.findMany({
       orderBy: { createdAt: 'desc' },
+      include: {
+        _count: { select: { userGroups: true } },
+      },
     });
   }
 
   findGroupById(groupId: number): Promise<Group | null> {
-    return this.prisma.group.findUnique({
-      where: { id: groupId },
-    });
+    return this.prisma.group.findUnique({ where: { id: groupId } });
   }
 
   getMemberCount(groupId: number): Promise<number> {
-    return this.prisma.userGroup.count({
-      where: { groupId },
-    });
+    return this.prisma.userGroup.count({ where: { groupId } });
   }
 
   findGroupUser(groupId: number, userId: number): Promise<UserGroup | null> {
-    return this.prisma.userGroup.findFirst({
-      where: { groupId, userId },
-    });
+    return this.prisma.userGroup.findFirst({ where: { groupId, userId } });
   }
 
   createGroupUser(data: GroupUserInput): Promise<UserGroup> {
@@ -69,5 +68,32 @@ export class GroupsRepository {
       where: { id: groupId },
       data,
     });
+  }
+
+  async findGroupImagePath(groupId: number): Promise<string | null> {
+    const group = await this.prisma.group.findUnique({
+      where: { id: groupId },
+      select: { groupImgPath: true },
+    });
+    return group?.groupImgPath ?? null;
+  }
+
+  async setGroupImagePathIfEmpty(
+    groupId: number,
+    imageKey: string,
+  ): Promise<boolean> {
+    const result = await this.prisma.group.updateMany({
+      where: { id: groupId, groupImgPath: null },
+      data: { groupImgPath: imageKey },
+    });
+    return result.count === 1;
+  }
+
+  async clearGroupImagePathIfPresent(groupId: number): Promise<boolean> {
+    const result = await this.prisma.group.updateMany({
+      where: { id: groupId, groupImgPath: { not: null } },
+      data: { groupImgPath: null },
+    });
+    return result.count === 1;
   }
 }

--- a/src/groups/groups.repository.ts
+++ b/src/groups/groups.repository.ts
@@ -1,4 +1,3 @@
-// src/groups/groups.repository.ts
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
 import {

--- a/src/groups/groups.service.ts
+++ b/src/groups/groups.service.ts
@@ -3,7 +3,6 @@ import {
   Injectable,
   NotFoundException,
   ConflictException,
-  BadRequestException,
 } from '@nestjs/common';
 import { CreateGroupDto } from './dto/create-group.dto';
 import { JoinGroupDto } from './dto/join-group.dto';
@@ -19,7 +18,6 @@ import { MembersService } from '../member/member.service';
 import { UserGroupRole } from '@prisma/client';
 import { S3Service } from 'src/s3/s3.service';
 import { S3ObjectType } from 'src/s3/s3.types';
-import { CreateGroupImageDto } from './dto/create-group-image.dto';
 
 @Injectable()
 export class GroupsService {
@@ -176,11 +174,11 @@ export class GroupsService {
     });
   }
 
-  async createGroupImage(
+  async upsertGroupImage(
     groupId: number,
     userId: number,
     fileToUpload?: Express.Multer.File,
-  ): Promise<CreateGroupImageDto> {
+  ): Promise<GroupResponseDto> {
     const group = await this.groupsRepository.findGroupById(groupId);
     if (!group) {
       throw new NotFoundException(`그룹 ID ${groupId}를 찾을 수 없습니다.`);
@@ -194,61 +192,39 @@ export class GroupsService {
       throw new ForbiddenException('그룹을 수정할 권한이 없습니다.');
     }
 
+    const previousKey = await this.groupsRepository.findGroupImagePath(groupId);
+
+    // 이미지 제거 요청
     if (!fileToUpload) {
-      throw new BadRequestException('업로드할 이미지가 없습니다.');
+      const isCleared =
+        await this.groupsRepository.clearGroupImagePathIfPresent(groupId);
+
+      if (isCleared && previousKey) {
+        await this.s3Service.deleteFile(previousKey).catch(() => undefined);
+      }
+
+      const updated = await this.groupsRepository.findGroupById(groupId);
+      return plainToInstance(GroupResponseDto, updated, {
+        excludeExtraneousValues: true,
+      });
     }
 
-    const uploadedImageKey = await this.s3Service.uploadFile(
+    // 이미지 교체 요청
+    const uploadedKey = await this.s3Service.uploadFile(
       fileToUpload,
       S3ObjectType.GROUP,
     );
 
-    const isSet = await this.groupsRepository.setGroupImagePathIfEmpty(
-      groupId,
-      uploadedImageKey,
-    );
+    const updatedGroup = await this.groupsRepository.updateGroupById(groupId, {
+      groupImgPath: uploadedKey,
+    });
 
-    if (!isSet) {
-      await this.s3Service.deleteFile(uploadedImageKey).catch(() => undefined);
-      throw new ConflictException(
-        '이미 그룹 이미지가 존재합니다. 먼저 삭제해주세요.',
-      );
+    if (previousKey) {
+      await this.s3Service.deleteFile(previousKey).catch(() => undefined);
     }
 
-    const imageUrl = this.s3Service.getFileUrl(uploadedImageKey);
-    return plainToInstance(
-      CreateGroupImageDto,
-      { imageKey: uploadedImageKey, imageUrl },
-      { excludeExtraneousValues: true },
-    );
-  }
-
-  async deleteGroupImage(groupId: number, userId: number): Promise<void> {
-    const group = await this.groupsRepository.findGroupById(groupId);
-    if (!group) {
-      throw new NotFoundException(`그룹 ID ${groupId}를 찾을 수 없습니다.`);
-    }
-
-    const userGroup = await this.groupsRepository.findGroupUser(
-      groupId,
-      userId,
-    );
-    if (!userGroup || userGroup.role !== UserGroupRole.MANAGER) {
-      throw new ForbiddenException('그룹을 수정할 권한이 없습니다.');
-    }
-
-    const previousImageKey =
-      await this.groupsRepository.findGroupImagePath(groupId);
-    if (!previousImageKey) {
-      return;
-    }
-
-    const isCleared =
-      await this.groupsRepository.clearGroupImagePathIfPresent(groupId);
-    if (!isCleared) {
-      return;
-    }
-
-    await this.s3Service.deleteFile(previousImageKey).catch(() => undefined);
+    return plainToInstance(GroupResponseDto, updatedGroup, {
+      excludeExtraneousValues: true,
+    });
   }
 }

--- a/src/groups/groups.service.ts
+++ b/src/groups/groups.service.ts
@@ -3,6 +3,7 @@ import {
   Injectable,
   NotFoundException,
   ConflictException,
+  BadRequestException,
 } from '@nestjs/common';
 import { CreateGroupDto } from './dto/create-group.dto';
 import { JoinGroupDto } from './dto/join-group.dto';
@@ -16,59 +17,81 @@ import { GroupUserResponseDto } from './dto/group-user-response.dto';
 import { CreateGroupInput, UpdateGroupInput } from './types/group-inputs';
 import { MembersService } from '../member/member.service';
 import { UserGroupRole } from '@prisma/client';
+import { S3Service } from 'src/s3/s3.service';
+import { S3ObjectType } from 'src/s3/s3.types';
+import { CreateGroupImageDto } from './dto/create-group-image.dto';
 
 @Injectable()
 export class GroupsService {
   constructor(
     private readonly groupsRepository: GroupsRepository,
     private readonly membersService: MembersService,
+    private readonly s3Service: S3Service,
   ) {}
 
   async createGroup(
     createGroupDto: CreateGroupDto,
     userId: number,
+    fileToUpload?: Express.Multer.File,
   ): Promise<GroupResponseDto> {
     const existingGroup = await this.groupsRepository.findGroupByName(
       createGroupDto.name,
     );
+    let groupImagePath: string | undefined;
+
     if (existingGroup) {
       throw new ConflictException('이미 존재하는 그룹 이름입니다.');
     }
 
-    const createGroupData: CreateGroupInput = {
-      ...createGroupDto,
-      userId,
-    };
+    try {
+      if (fileToUpload) {
+        groupImagePath = await this.s3Service.uploadFile(
+          fileToUpload,
+          S3ObjectType.GROUP,
+        );
+      }
 
-    const createdGroup =
-      await this.groupsRepository.createGroupWithAdmin(createGroupData);
-    return plainToInstance(GroupResponseDto, createdGroup, {
-      excludeExtraneousValues: true,
-    });
+      const createGroupData: CreateGroupInput = {
+        ...createGroupDto,
+        userId,
+        groupImagePath,
+      };
+
+      const createdGroup =
+        await this.groupsRepository.createGroupWithAdmin(createGroupData);
+
+      return plainToInstance(GroupResponseDto, createdGroup, {
+        excludeExtraneousValues: true,
+      });
+    } catch (err) {
+      if (groupImagePath) {
+        await this.s3Service.deleteFile(groupImagePath);
+      }
+      throw err;
+    }
   }
 
   async findAllGroups(): Promise<GroupWithMemberCountDto[]> {
     const groups = await this.groupsRepository.findAllGroups();
 
-    const groupsWithCounts = await Promise.all(
+    return Promise.all(
       groups.map(async (group) => {
-        const memberCount = await this.groupsRepository.getMemberCount(
-          group.id,
-        );
+        const groupImagePath = group.groupImgPath ?? null;
+        const groupImageUrl = groupImagePath
+          ? this.s3Service.getFileUrl(groupImagePath)
+          : null;
+
         return plainToInstance(
           GroupWithMemberCountDto,
           {
             ...group,
-            memberCount,
+            memberCount: group._count.userGroups,
+            groupImageUrl,
           },
-          {
-            excludeExtraneousValues: true,
-          },
+          { excludeExtraneousValues: true },
         );
       }),
     );
-
-    return groupsWithCounts;
   }
 
   async getGroupWithJoinStatus(
@@ -79,6 +102,10 @@ export class GroupsService {
     if (!group) {
       throw new NotFoundException(`그룹 ID ${groupId}를 찾을 수 없습니다.`);
     }
+    const groupImagePath = group.groupImgPath ?? null;
+    const groupImageUrl = groupImagePath
+      ? this.s3Service.getFileUrl(groupImagePath)
+      : null;
 
     if (!userId) {
       return plainToInstance(
@@ -103,6 +130,7 @@ export class GroupsService {
       {
         isJoined: !!userGroup,
         role: userGroup?.role ?? null,
+        groupImageUrl,
       },
       {
         excludeExtraneousValues: true,
@@ -146,5 +174,81 @@ export class GroupsService {
     return plainToInstance(GroupResponseDto, updatedGroup, {
       excludeExtraneousValues: true,
     });
+  }
+
+  async createGroupImage(
+    groupId: number,
+    userId: number,
+    fileToUpload?: Express.Multer.File,
+  ): Promise<CreateGroupImageDto> {
+    const group = await this.groupsRepository.findGroupById(groupId);
+    if (!group) {
+      throw new NotFoundException(`그룹 ID ${groupId}를 찾을 수 없습니다.`);
+    }
+
+    const userGroup = await this.groupsRepository.findGroupUser(
+      groupId,
+      userId,
+    );
+    if (!userGroup || userGroup.role !== UserGroupRole.MANAGER) {
+      throw new ForbiddenException('그룹을 수정할 권한이 없습니다.');
+    }
+
+    if (!fileToUpload) {
+      throw new BadRequestException('업로드할 이미지가 없습니다.');
+    }
+
+    const uploadedImageKey = await this.s3Service.uploadFile(
+      fileToUpload,
+      S3ObjectType.GROUP,
+    );
+
+    const isSet = await this.groupsRepository.setGroupImagePathIfEmpty(
+      groupId,
+      uploadedImageKey,
+    );
+
+    if (!isSet) {
+      await this.s3Service.deleteFile(uploadedImageKey).catch(() => undefined);
+      throw new ConflictException(
+        '이미 그룹 이미지가 존재합니다. 먼저 삭제해주세요.',
+      );
+    }
+
+    const imageUrl = this.s3Service.getFileUrl(uploadedImageKey);
+    return plainToInstance(
+      CreateGroupImageDto,
+      { imageKey: uploadedImageKey, imageUrl },
+      { excludeExtraneousValues: true },
+    );
+  }
+
+  async deleteGroupImage(groupId: number, userId: number): Promise<void> {
+    const group = await this.groupsRepository.findGroupById(groupId);
+    if (!group) {
+      throw new NotFoundException(`그룹 ID ${groupId}를 찾을 수 없습니다.`);
+    }
+
+    const userGroup = await this.groupsRepository.findGroupUser(
+      groupId,
+      userId,
+    );
+    if (!userGroup || userGroup.role !== UserGroupRole.MANAGER) {
+      throw new ForbiddenException('그룹을 수정할 권한이 없습니다.');
+    }
+
+    const previousImageKey =
+      await this.groupsRepository.findGroupImagePath(groupId);
+    if (!previousImageKey) {
+      return;
+    }
+
+    const isCleared =
+      await this.groupsRepository.clearGroupImagePathIfPresent(groupId);
+    if (!isCleared) {
+      return;
+    }
+
+    await this.s3Service.deleteFile(previousImageKey).catch(() => undefined);
   }
 }

--- a/src/groups/types/group-inputs.ts
+++ b/src/groups/types/group-inputs.ts
@@ -4,6 +4,7 @@ export interface CreateGroupInput {
   name: string;
   description: string;
   userId: number;
+  groupImagePath?: string;
 }
 
 export interface GroupUserInput {
@@ -15,4 +16,8 @@ export interface GroupUserInput {
 export interface UpdateGroupInput {
   name?: string;
   description?: string;
+}
+
+export interface CreateGroupImageInput {
+  groupImagePath: string;
 }

--- a/src/groups/types/group-inputs.ts
+++ b/src/groups/types/group-inputs.ts
@@ -11,11 +11,13 @@ export interface GroupUserInput {
   userId: number;
   groupId: number;
   role: UserGroupRole;
+  groupImagePath?: string;
 }
 
 export interface UpdateGroupInput {
   name?: string;
   description?: string;
+  groupImgPath?: string;
 }
 
 export interface CreateGroupImageInput {


### PR DESCRIPTION
관련 이슈
-
#77 

📝 제목
-
그룹 이미지 관련 S3를 통한 이미지 업로드 및 삭제 추가

📋 작업 내용
-
- [x]  그룹 최초 생성 시 이미지 업로드 가능
- [x]  그룹 이미지 추가 및 삭제 기능 구현 (직접적인 업데이트 기능은 제공하지 않음)
- [x]  리팩토링은 별도 브랜치에서 진행 예정


🚀 테스트 사항
-
- Postman을 통한 그룹 생성 시 이미지 업로드 테스트
- 이미지 단독 추가 기능 테스트
- 이미지 삭제 기능 테스트 및 S3 스토리지 객체 삭제 확인