### PR TITLE
feat: (#90) 게시물 조회시 isLiked, likesCount 필드 추가

### DIFF
--- a/src/likes/post-likes.module.ts
+++ b/src/likes/post-likes.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { GroupsModule } from 'src/groups/groups.module';
 import { PostsModule } from 'src/posts/posts.module';
 import { PostLikesController } from './post-likes.controller';
@@ -6,8 +6,9 @@ import { PostLikesRepository } from './post-likes.repository';
 import { PostLikesService } from './post-likes.service';
 
 @Module({
-  imports: [GroupsModule, PostsModule],
+  imports: [GroupsModule, forwardRef(() => PostsModule)],
   controllers: [PostLikesController],
   providers: [PostLikesRepository, PostLikesService],
+  exports: [PostLikesRepository],
 })
 export class PostLikesModule {}

--- a/src/likes/post-likes.repository.ts
+++ b/src/likes/post-likes.repository.ts
@@ -46,11 +46,19 @@ export class PostLikesRepository {
     });
   }
 
-  // 게시물 좋아요 개수 조회
-  async getPostLikeCount(postId: number): Promise<number> {
-    const count = await this.prisma.postLike.count({
-      where: { postId: postId },
+  // 해당 유저가 좋아요 누른 게시물 ID 목록 조회
+  async findLikedPostIdsByUser(
+    userId: number,
+    postIds: number[],
+  ): Promise<number[]> {
+    const likes = await this.prisma.postLike.findMany({
+      where: {
+        userId,
+        postId: { in: postIds },
+      },
+      select: { postId: true },
     });
-    return count;
+
+    return likes.map((like) => like.postId);
   }
 }

--- a/src/posts/dto/responses/post-response.dto.ts
+++ b/src/posts/dto/responses/post-response.dto.ts
@@ -44,6 +44,14 @@ export class PostResponseDto {
   @Expose()
   commentsCount: number;
 
+  @ApiProperty({ example: 9, required: false, description: '좋아요 수' })
+  @Expose()
+  likesCount: number;
+
+  @ApiProperty({ example: 9, required: false, description: '좋아요 수' })
+  @Expose()
+  isLiked: boolean;
+
   @ApiProperty({
     example:
       'https://your-bucket.s3.ap-northeast-2.amazonaws.com/posts/uuid.jpeg',

--- a/src/posts/interfaces/post.interface.ts
+++ b/src/posts/interfaces/post.interface.ts
@@ -10,7 +10,6 @@ export interface Post {
   updatedAt: Date | null;
   category: PostCategory;
 }
-
 export interface PostWithUser extends Post {
   user: {
     id: number;
@@ -18,23 +17,26 @@ export interface PostWithUser extends Post {
   };
 }
 
+export interface PostWithUserAndCountRaw extends PostWithUser {
+  _count: {
+    comments: number;
+    postLikes: number;
+  };
+  postImages: PostImage[];
+}
+
+export interface PostSummary extends PostWithUser {
+  commentsCount: number;
+  likesCount: number;
+  postImageUrl: string | null;
+  isLiked: boolean;
+}
+
 export interface PostImage {
   id: number;
   postId: number;
   postImgPath: string;
   createdAt: Date;
-}
-
-export interface PostWithUserAndCount extends PostWithUser {
-  _count: {
-    comments: number;
-  };
-  postImages: PostImage[];
-}
-
-export interface PostWithCommentCount extends PostWithUser {
-  commentsCount: number;
-  postImageUrl?: string | null;
 }
 
 export interface CreatePostData {

--- a/src/posts/posts.module.ts
+++ b/src/posts/posts.module.ts
@@ -1,11 +1,12 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { PostsController } from './posts.controller';
 import { PostsRepository } from './posts.repository';
 import { PostsService } from './posts.service';
 import { S3Module } from 'src/s3/s3.module';
+import { PostLikesModule } from 'src/likes/post-likes.module';
 
 @Module({
-  imports: [S3Module],
+  imports: [S3Module, forwardRef(() => PostLikesModule)],
   controllers: [PostsController],
   providers: [PostsService, PostsRepository],
   exports: [PostsRepository],

--- a/src/posts/posts.repository.ts
+++ b/src/posts/posts.repository.ts
@@ -3,7 +3,7 @@ import { Post, Prisma } from '@prisma/client';
 import { PrismaService } from 'src/prisma/prisma.service';
 import {
   CreatePostData,
-  PostWithUserAndCount,
+  PostWithUserAndCountRaw,
   UpdatePostData,
 } from './interfaces/post.interface';
 
@@ -51,7 +51,7 @@ export class PostsRepository {
 
   async findPostsWithCommentsCount(
     groupId: number,
-  ): Promise<PostWithUserAndCount[]> {
+  ): Promise<PostWithUserAndCountRaw[]> {
     return await this.prisma.post.findMany({
       where: { groupId },
       orderBy: { createdAt: 'desc' },
@@ -65,6 +65,7 @@ export class PostsRepository {
         _count: {
           select: {
             comments: true,
+            postLikes: true,
           },
         },
         postImages: true,
@@ -75,7 +76,7 @@ export class PostsRepository {
   async findPostById(
     id: number,
     tx?: TxClient,
-  ): Promise<PostWithUserAndCount | null> {
+  ): Promise<PostWithUserAndCountRaw | null> {
     return await (tx ?? this.prisma).post.findUnique({
       where: { id },
       include: {
@@ -88,6 +89,7 @@ export class PostsRepository {
         _count: {
           select: {
             comments: true,
+            postLikes: true,
           },
         },
         postImages: true,

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -9,17 +9,19 @@ import {
   CreatePostData,
   UpdatePostData,
   Post,
-  PostWithCommentCount,
+  PostSummary,
 } from './interfaces/post.interface';
 import { PostsRepository } from './posts.repository';
 import { S3ObjectType } from 'src/s3/s3.types';
 import { S3Service } from 'src/s3/s3.service';
+import { PostLikesRepository } from 'src/likes/post-likes.repository';
 
 @Injectable()
 export class PostsService {
   constructor(
     private readonly postsRepository: PostsRepository,
     private readonly s3Service: S3Service,
+    private readonly postLikesRepository: PostLikesRepository,
   ) {}
 
   async createPost(
@@ -59,10 +61,15 @@ export class PostsService {
 
   async findAllPostsByGroupId(
     groupId: number,
-  ): Promise<PostWithCommentCount[]> {
+    userId: number,
+  ): Promise<PostSummary[]> {
     const posts =
       await this.postsRepository.findPostsWithCommentsCount(groupId);
+    const postIds = posts.map((post) => post.id);
 
+    const likedPostIds = new Set(
+      await this.postLikesRepository.findLikedPostIdsByUser(userId, postIds),
+    );
     return posts.map((post) => {
       const imagePath = post.postImages?.[0]?.postImgPath;
       const postImageUrl = imagePath
@@ -72,28 +79,31 @@ export class PostsService {
       return {
         ...post,
         commentsCount: post._count.comments,
+        likesCount: post._count.postLikes,
         postImageUrl,
+        isLiked: likedPostIds.has(post.id),
       };
     });
   }
 
-  async getPostById(id: number): Promise<PostWithCommentCount> {
-    const post = await this.postsRepository.findPostById(id);
-    if (!post) {
-      throw new NotFoundException(`ID가 ${id}인 게시물을 찾을 수 없습니다.`);
-    }
+  // async getPostById(id: number): Promise<PostSummary> {
+  //   const post = await this.postsRepository.findPostById(id);
+  //   if (!post) {
+  //     throw new NotFoundException(`ID가 ${id}인 게시물을 찾을 수 없습니다.`);
+  //   }
 
-    const imagePath = post.postImages?.[0]?.postImgPath;
-    const postImageUrl = imagePath
-      ? this.s3Service.getFileUrl(imagePath)
-      : null;
+  //   const imagePath = post.postImages?.[0]?.postImgPath;
+  //   const postImageUrl = imagePath
+  //     ? this.s3Service.getFileUrl(imagePath)
+  //     : null;
 
-    return {
-      ...post,
-      commentsCount: post._count.comments,
-      postImageUrl,
-    };
-  }
+  //   return {
+  //     ...post,
+  //     commentsCount: post._count.comments,
+  //     likesCount: post._count.postLikes,
+  //     postImageUrl,
+  //   };
+  // }
 
   async updatePost(
     updatePostDto: UpdatePostRequestDto,


### PR DESCRIPTION
관련 이슈
-
#90 
📝 제목
-
[feat] 게시물 조회시 isLiked, likesCount 필드 추가

📋 작업 내용
-
- [ ]  그룹 내 게시글 조회 시 `likesCount` 필드 추가
- [ ]  현재 로그인한 사용자의 좋아요 여부 `isLiked` 필드 추가 
- [ ]  리팩토링 (필요 시) 

🔧 기술 변경
-
 - postLikesRepository에 `findLikedPostIdsByUser` 메서드 추가
 - 게시글 서비스에서 `Set`을 활용한 `isLiked` 판단 로직 추가

🚀 테스트 사항(선택)
-
- Postman으로 게시글 목록 조회 API 테스트
- 좋아요 누른 사용자일 경우 `isLiked: true` 반환 확인
 <!-- 예외 처리 확인 -->