### PR TITLE
feat(#88): 회원가입 시 기본 프로필 이미지 자동 부여 로직 추가

### DIFF
--- a/prisma/migrations/20250811092110_add_profile_img_path_to_user/migration.sql
+++ b/prisma/migrations/20250811092110_add_profile_img_path_to_user/migration.sql
@@ -1,0 +1,5 @@
+-- DropIndex
+DROP INDEX "post_images_post_img_path_key";
+
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "profile_img_path" VARCHAR(255);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,17 +20,23 @@ enum MembershipStatus {
   LEFT
 }
 
+enum PostCategory {
+  NORMAL
+  ANNOUNCEMENT
+}
+
 //// ===== Models =====
 model User {
-  id         Int         @id @default(autoincrement())
-  username   String      @unique @map("user_name") @db.VarChar(20)
-  password   String      @db.VarChar(60)
-  name       String      @db.VarChar(50)
-  createdAt  DateTime    @default(now()) @map("created_at")
-  comments   Comment[]
-  postLikes  PostLike[]
-  posts      Post[]
-  userGroups UserGroup[]
+  id             Int         @id @default(autoincrement())
+  username       String      @unique @map("user_name") @db.VarChar(20)
+  password       String      @db.VarChar(60)
+  name           String      @db.VarChar(50)
+  profileImgPath String?     @map("profile_img_path") @db.VarChar(255)
+  createdAt      DateTime    @default(now()) @map("created_at")
+  comments       Comment[]
+  postLikes      PostLike[]
+  posts          Post[]
+  userGroups     UserGroup[]
 
   @@map("users")
 }
@@ -40,7 +46,7 @@ model Group {
   name         String      @db.VarChar(100)
   description  String?
   createdAt    DateTime    @default(now()) @map("created_at")
-  groupImgPath String?     @map("group_img_path")        // ← 추가
+  groupImgPath String?     @map("group_img_path") @db.VarChar(255)
   posts        Post[]
   userGroups   UserGroup[]
 
@@ -48,47 +54,53 @@ model Group {
 }
 
 model UserGroup {
-  id        Int               @id @default(autoincrement())
-  userId    Int               @map("user_id")
-  groupId   Int               @map("group_id")
-  role      UserGroupRole                                 // ← String → enum
-  status    MembershipStatus   @default(PENDING)          // ← 추가
-  leftAt    DateTime?          @map("left_at")            // ← 추가
-  createdAt DateTime           @default(now()) @map("created_at")
+  id        Int              @id @default(autoincrement())
+  userId    Int              @map("user_id")
+  groupId   Int              @map("group_id")
+  role      UserGroupRole    @default(MEMBER)
+  status    MembershipStatus @default(PENDING)
+  leftAt    DateTime?        @map("left_at")
+  createdAt DateTime         @default(now()) @map("created_at")
 
-  group     Group    @relation(fields: [groupId], references: [id], onDelete: Cascade)
-  user     User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  group Group @relation(fields: [groupId], references: [id], onDelete: Cascade)
+  user  User  @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([userId, groupId])
+  @@index([groupId, status]) // 특정 그룹의 멤버 상태별 조회 (예: 가입 대기 멤버)
+  @@index([userId, status]) // 특정 유저의 가입 그룹 상태별 조회 (예: 유저가 가입 대기 중인 그룹)
+  @@index([groupId]) // 특정 그룹의 모든 멤버를 조회할 때 (status 필터링 없이)
+  @@index([userId]) // 특정 유저가 속한 모든 그룹을 조회할 때 (status 필터링 없이)
   @@map("user_groups")
 }
 
 model Post {
-  id         Int          @id @default(autoincrement())
-  userId     Int          @map("user_id")
-  groupId    Int          @map("group_id")
-  title      String       @db.VarChar(255)
-  content    String
-  createdAt  DateTime     @default(now()) @map("created_at")
-  updatedAt  DateTime?    @map("updated_at")
-  category   PostCategory @default(NORMAL)
+  id        Int          @id @default(autoincrement())
+  userId    Int          @map("user_id")
+  groupId   Int          @map("group_id")
+  title     String       @db.VarChar(255)
+  content   String
+  category  PostCategory @default(NORMAL)
+  createdAt DateTime     @default(now()) @map("created_at")
+  updatedAt DateTime?    @map("updated_at")
+
   comments   Comment[]
   postImages PostImage[]
   postLikes  PostLike[]
-  group      Group        @relation(fields: [groupId], references: [id], onDelete: Cascade)
-  user       User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  group Group @relation(fields: [groupId], references: [id], onDelete: Cascade)
+  user  User  @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([groupId, createdAt])
   @@map("posts")
 }
 
 model PostImage {
-  id          Int       @id @default(autoincrement())
-  postId      Int       @map("post_id")
-  postImgPath String    @unique @map("post_img_path")   // ← url → path 필드 교체
-  createdAt   DateTime  @default(now()) @map("created_at")
+  id          Int      @id @default(autoincrement())
+  postId      Int      @map("post_id")
+  postImgPath String   @map("post_img_path") @db.VarChar(255)
+  createdAt   DateTime @default(now()) @map("created_at")
 
-  post        Post      @relation(fields: [postId], references: [id], onDelete: Cascade)
+  post Post @relation(fields: [postId], references: [id], onDelete: Cascade)
 
   @@map("post_images")
 }
@@ -101,6 +113,7 @@ model PostLike {
   user   User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([postId, userId])
+  @@index([postId])
   @@map("post_likes")
 }
 
@@ -120,9 +133,4 @@ model Comment {
   @@index([postId])
   @@index([parentId])
   @@map("comments")
-}
-
-enum PostCategory {
-  NORMAL
-  ANNOUNCEMENT
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -28,6 +28,7 @@ export class AuthService {
     const hashedPassword = await this.passwordEncoderService.hash(
       signupRequestDto.password,
     );
+
     await this.usersService.createUser({
       username: signupRequestDto.username,
       name: signupRequestDto.name,

--- a/src/users/dto/reponses/user-profile.dto.ts
+++ b/src/users/dto/reponses/user-profile.dto.ts
@@ -13,4 +13,11 @@ export class UserProfileDto {
   @Expose()
   @ApiProperty({ example: 'user123', description: '사용자 아이디' })
   username: string;
+
+  @Expose()
+  @ApiProperty({
+    example: 'https://example.com/profile/default_1.png',
+    description: '프로필 이미지 URL',
+  })
+  profileImgPath: string;
 }

--- a/src/users/interfaces/users.interface.ts
+++ b/src/users/interfaces/users.interface.ts
@@ -2,8 +2,23 @@ import { Prisma, User } from '@prisma/client';
 
 export interface IUsersRepository {
   findByUsername(username: string): Promise<User | null>;
-
   findUserById(id: number): Promise<User | null>;
-
-  createUser(userData: Prisma.UserCreateInput): Promise<User>;
+  createUser(userData: CreateUserInput): Promise<User>;
 }
+
+export interface IUsersService {
+  createUser(userData: CreateUserInput): Promise<User>;
+  findUserByUsername(username: string): Promise<User | null>;
+  findMyProfile(userId: number): Promise<UserProfile>;
+}
+export interface UserSummary {
+  userId: number;
+  name: string;
+  username: string;
+}
+
+export interface UserProfile extends UserSummary {
+  profileImgPath: string | null;
+}
+
+export type CreateUserInput = Prisma.UserCreateInput;

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
+import { S3Module } from 'src/s3/s3.module';
 import { UsersController } from './users.controller';
 import { UsersRepository } from './users.repository';
 import { UsersService } from './users.service';
 
 @Module({
+  imports: [S3Module],
   controllers: [UsersController],
   providers: [UsersService, UsersRepository],
   exports: [UsersService],

--- a/src/users/users.repository.ts
+++ b/src/users/users.repository.ts
@@ -1,7 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { User } from '@prisma/client';
 import { PrismaService } from 'src/prisma/prisma.service';
-import { IUsersRepository } from './interfaces/users.interface';
+import {
+  CreateUserInput,
+  IUsersRepository,
+} from './interfaces/users.interface';
 
 @Injectable()
 export class UsersRepository implements IUsersRepository {
@@ -15,11 +18,7 @@ export class UsersRepository implements IUsersRepository {
     return this.prisma.user.findUnique({ where: { id } });
   }
 
-  async createUser(data: {
-    username: string;
-    name: string;
-    password: string;
-  }): Promise<User> {
+  async createUser(data: CreateUserInput): Promise<User> {
     return this.prisma.user.create({ data });
   }
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,14 +1,56 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
-import { Prisma, User } from '@prisma/client';
+import {
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { User } from '@prisma/client';
 import { plainToInstance } from 'class-transformer';
+import { S3Service } from 'src/s3/s3.service';
 import { UserProfileDto } from 'src/users/dto/reponses/user-profile.dto';
+import { CreateUserInput, IUsersService } from './interfaces/users.interface';
 import { UsersRepository } from './users.repository';
 
 @Injectable()
-export class UsersService {
-  constructor(private readonly usersRepository: UsersRepository) {}
+export class UsersService implements IUsersService {
+  constructor(
+    private readonly s3Service: S3Service,
+    private readonly configService: ConfigService,
+    private readonly usersRepository: UsersRepository,
+  ) {}
 
-  async createUser(userData: Prisma.UserCreateInput): Promise<User> {
+  // 사용자 찾기
+  private async findUserOrThrow(userId: number): Promise<User> {
+    const user = await this.usersRepository.findUserById(userId);
+    if (!user) {
+      throw new NotFoundException('사용자를 찾을 수 없습니다.');
+    }
+    return user;
+  }
+
+  // 기본 이미지 URL 목록 가져오기
+  private getDefaultImageKeys(): string[] {
+    const defaultImagesString = this.configService.get<string>(
+      'DEFAULT_PROFILE_IMAGE_URL',
+    );
+    if (!defaultImagesString) {
+      throw new InternalServerErrorException(
+        '기본 프로필 이미지 URL 설정 오류',
+      );
+    }
+    return defaultImagesString.split(',');
+  }
+
+  // 기본 이미지 중 랜덤으로 하나 선택
+  private getRandomDefaultImageKey(): string {
+    const defaultKeys = this.getDefaultImageKeys();
+    const randomIndex = Math.floor(Math.random() * defaultKeys.length);
+    return defaultKeys[randomIndex];
+  }
+
+  // 유저 생성 시 프로필 이미지 부여
+  async createUser(userData: CreateUserInput): Promise<User> {
+    userData.profileImgPath = this.getRandomDefaultImageKey();
     return this.usersRepository.createUser(userData);
   }
 
@@ -17,11 +59,12 @@ export class UsersService {
   }
 
   async findMyProfile(userId: number): Promise<UserProfileDto> {
-    const user: User | null = await this.usersRepository.findUserById(userId);
+    const user = await this.findUserOrThrow(userId);
 
-    if (!user) {
-      throw new NotFoundException('사용자를 찾을 수 없습니다.');
-    }
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const profileImgKey =
+      user.profileImgPath ?? this.getRandomDefaultImageKey();
+    const profileImgUrl = this.s3Service.getFileUrl(profileImgKey);
 
     return plainToInstance(
       UserProfileDto,
@@ -29,6 +72,7 @@ export class UsersService {
         userId: user.id,
         name: user.name,
         username: user.username,
+        profileImgPath: profileImgUrl,
       },
       { excludeExtraneousValues: true },
     );


### PR DESCRIPTION
관련 이슈
-
- #88 

📝 제목
-
[Feature] 회원가입 시 기본 프로필 이미지 자동 부여 기능 구현

📋 작업 내용
-
- [ ]   회원가입 API에서 유저 생성 시 기본 프로필 이미지 랜덤 부여 로직 추가
- [ ] 기본 프로필 이미지 URL 목록을 환경변수(DEFAULT_PROFILE_IMAGE_URL)에서 불러와 관리하도록 구현
- [ ]  기존 사용자 프로필 조회 API가 프로필 이미지 URL을 정상적으로 반환하는지 검증 및 유지

🔧 기술 변경
-
 ConfigService 사용하여 기본 이미지 URL 리스트 관리
 UsersService에서 프로필 이미지 처리 로직 추가

🚀 테스트 사항(선택)
-
회원가입 시, DEFAULT_PROFILE_IMAGE_URL 목록 중 하나 랜덤 부여 확인
users/me API 호출 시, 유저의 프로필 이미지 URL이 정상적으로 반환되는지 확인
DEFAULT_PROFILE_IMAGE_URL 설정이 없을 때 적절한 예외가 발생 확인

💬 리뷰 요구사항 (선택)

인터페이스, 로직 분리 부분에 대해 의견 주시면 감사하겠습니다.