### PR TITLE
feat: (#98) 그룹 삭제 API 구현

### DIFF
--- a/src/groups/groups.service.ts
+++ b/src/groups/groups.service.ts
@@ -215,4 +215,25 @@ export class GroupsService {
       excludeExtraneousValues: true,
     });
   }
+
+  async removeGroup(groupId: number, userId: number): Promise<void> {
+    const group = await this.groupsRepository.findGroupById(groupId);
+    if (!group) {
+      throw new NotFoundException(`그룹 ID ${groupId}를 찾을 수 없습니다.`);
+    }
+
+    const membership = await this.groupsRepository.findGroupUser(
+      groupId,
+      userId,
+    );
+    if (!membership || membership.role !== UserGroupRole.MANAGER) {
+      throw new ForbiddenException('그룹을 삭제할 권한이 없습니다.');
+    }
+
+    await this.groupsRepository.deleteGroupById(groupId);
+
+    await this.s3Service
+      .deleteAllByPrefixes([`group/${groupId}/`, `post/${groupId}/`])
+      .catch(() => undefined);
+  }
 }


### PR DESCRIPTION
관련 이슈
-
#98 

📝 제목
-
[feat] 그룹 삭제 API

📋 작업 내용
-
- [ ]  그룹 삭제 API 엔드포인트 구현
- [ ]  그룹 삭제 시 관련 데이터 정리 로직 추가
- [ ]  권한 검증: 그룹 내 MANAGER 권한만 삭제 허용

🔧 기술 변경
-
- groupsRepository.findGroupById, findGroupUser 활용
- removeGroup(groupId, userId) 구현

 <!-- 폴더/파일 구조 변경 -->

🚀 테스트 사항(선택)
-
- Postman으로 기본 플로우 수동 검증
- S3 실제 삭제 확인: 테스트 버킷에서 group/{groupId}/, post/{groupId}/ 오브젝트 소거 확인

## 💬 리뷰 요구사항 (선택)  
- deleteAllByPrefixes 배치/페이징 처리 성능 이슈 우려되는 부분 있는지

