### PR TITLE
feat: (#82) 멤버 역할 변경 기능 추가 및 관련 API 구현

### DIFF
--- a/src/member/dto/update-member-role.dto.ts
+++ b/src/member/dto/update-member-role.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum } from 'class-validator';
+import { UserGroupRole } from '@prisma/client';
+
+export class UpdateMemberRoleDto {
+  @ApiProperty({ enum: UserGroupRole, description: '변경할 역할' })
+  @IsEnum(UserGroupRole, { message: '역할은 MEMBER 또는 MANAGER 여야 합니다.' })
+  role!: UserGroupRole;
+}

--- a/src/member/member.controller.ts
+++ b/src/member/member.controller.ts
@@ -16,6 +16,7 @@ import { AuthenticatedUser } from '../auth/interfaces/authenticated-user.interfa
 import { MemberResponseDto } from './dto/member-response.dto';
 import { JoinMemberRequestDto } from './dto/join-member-request.dto';
 import { UpdateMemberStatusDto } from './dto/update-member-status.dto';
+import { UpdateMemberRoleDto } from './dto/update-member-role.dto';
 import { MemberSwagger, ApiMembers } from './member.swagger';
 import { ApiBearerAuth } from '@nestjs/swagger';
 import { User } from '../auth/user.decorator';
@@ -74,11 +75,31 @@ export class MembersController {
     @Param('groupId', ParseIntPipe) groupId: number,
     @Param('id', ParseIntPipe) userId: number,
     @Body() updateStatusDto: UpdateMemberStatusDto,
+    @User() user: AuthenticatedUser,
   ): Promise<{ message: string; member: MemberResponseDto }> {
     return this.membersService.updateMemberStatus(
       groupId,
       userId,
       updateStatusDto.action,
+      user.userId,
+    );
+  }
+
+  @UseGuards(CustomJwtAuthGuard, GroupManagerGuard)
+  @Post(':id/role')
+  @ApiBearerAuth('access-token')
+  @ApiMembers.updateRole()
+  async updateMemberRole(
+    @Param('groupId', ParseIntPipe) groupId: number,
+    @Param('id', ParseIntPipe) targetUserId: number,
+    @Body() dto: UpdateMemberRoleDto,
+    @User() user: AuthenticatedUser,
+  ): Promise<{ message: string; member: MemberResponseDto }> {
+    return this.membersService.updateMemberRole(
+      groupId,
+      user.userId,
+      targetUserId,
+      dto,
     );
   }
 }

--- a/src/member/member.controller.ts
+++ b/src/member/member.controller.ts
@@ -6,7 +6,6 @@ import {
   UseGuards,
   Post,
   Body,
-  Query,
 } from '@nestjs/common';
 import { MembersService } from './member.service';
 import { GroupMemberGuard } from './guards/group-member.guard';
@@ -20,86 +19,126 @@ import { UpdateMemberRoleDto } from './dto/update-member-role.dto';
 import { MemberSwagger, ApiMembers } from './member.swagger';
 import { ApiBearerAuth } from '@nestjs/swagger';
 import { User } from '../auth/user.decorator';
+import { ApiResponseDto } from '../common/dto/api-response.dto';
+import { MemberAction } from './member-action.enum';
 
 @Controller('groups/:groupId/members')
 @MemberSwagger()
+@ApiBearerAuth('access-token')
+@UseGuards(CustomJwtAuthGuard)
 export class MembersController {
   constructor(private readonly membersService: MembersService) {}
 
-  @UseGuards(CustomJwtAuthGuard, GroupMemberGuard)
+  @UseGuards(GroupMemberGuard)
   @Get()
-  @ApiBearerAuth('access-token')
   @ApiMembers.getList()
   async getMemberList(
     @Param('groupId', ParseIntPipe) groupId: number,
-    @Query('status') status?: string,
-  ): Promise<MemberResponseDto[]> {
-    return this.membersService.getMembersByGroupWithStatusString(
-      groupId,
-      status,
-    );
+  ): Promise<ApiResponseDto<MemberResponseDto[]>> {
+    const data = await this.membersService.getMembersByGroup(groupId);
+    return {
+      status: 'success',
+      message: '멤버 목록이 성공적으로 조회되었습니다.',
+      data,
+    };
   }
 
-  @UseGuards(CustomJwtAuthGuard, GroupMemberGuard)
+  @UseGuards(GroupMemberGuard)
   @Get(':id')
-  @ApiBearerAuth('access-token')
   @ApiMembers.getOne()
   async getGroupMember(
     @Param('groupId', ParseIntPipe) groupId: number,
     @Param('id', ParseIntPipe) id: number,
-  ): Promise<MemberResponseDto> {
-    return this.membersService.getGroupMember(groupId, id);
+  ): Promise<ApiResponseDto<MemberResponseDto>> {
+    const data = await this.membersService.getGroupMember(groupId, id);
+    return {
+      status: 'success',
+      message: '멤버가 성공적으로 조회되었습니다.',
+      data,
+    };
   }
 
-  @UseGuards(CustomJwtAuthGuard)
   @Post()
-  @ApiBearerAuth('access-token')
   @ApiMembers.join()
   async joinGroup(
     @Param('groupId', ParseIntPipe) groupId: number,
     @Body() joinMemberDto: JoinMemberRequestDto,
     @User() user: AuthenticatedUser,
-  ): Promise<{ message: string; member: MemberResponseDto }> {
-    return this.membersService.joinGroup({
+  ): Promise<ApiResponseDto<MemberResponseDto>> {
+    const member = await this.membersService.joinGroup({
       ...joinMemberDto,
       groupId,
       userId: user.userId,
     });
+    return {
+      status: 'success',
+      message: '가입 신청이 완료되었습니다. 관리자의 승인을 기다려주세요.',
+      data: member,
+    };
   }
 
-  @UseGuards(CustomJwtAuthGuard, GroupManagerGuard)
+  @UseGuards(GroupManagerGuard)
   @Post(':id/status')
-  @ApiBearerAuth('access-token')
   @ApiMembers.updateStatus()
   async updateMemberStatus(
     @Param('groupId', ParseIntPipe) groupId: number,
     @Param('id', ParseIntPipe) userId: number,
     @Body() updateStatusDto: UpdateMemberStatusDto,
     @User() user: AuthenticatedUser,
-  ): Promise<{ message: string; member: MemberResponseDto }> {
-    return this.membersService.updateMemberStatus(
+  ): Promise<ApiResponseDto<MemberResponseDto>> {
+    const member = await this.membersService.updateMemberStatus(
       groupId,
       userId,
       updateStatusDto.action,
       user.userId,
     );
+    const messageMap = {
+      APPROVE: '가입 신청이 승인되었습니다.',
+      REJECT: '가입 신청이 거절되었습니다.',
+      LEFT: '그룹을 탈퇴했습니다.',
+    } as const;
+    return {
+      status: 'success',
+      message: messageMap[updateStatusDto.action],
+      data: member,
+    };
   }
 
-  @UseGuards(CustomJwtAuthGuard, GroupManagerGuard)
+  @UseGuards(GroupManagerGuard)
   @Post(':id/role')
-  @ApiBearerAuth('access-token')
   @ApiMembers.updateRole()
   async updateMemberRole(
     @Param('groupId', ParseIntPipe) groupId: number,
     @Param('id', ParseIntPipe) targetUserId: number,
     @Body() dto: UpdateMemberRoleDto,
     @User() user: AuthenticatedUser,
-  ): Promise<{ message: string; member: MemberResponseDto }> {
-    return this.membersService.updateMemberRole(
+  ): Promise<ApiResponseDto<MemberResponseDto>> {
+    const member = await this.membersService.updateMemberRole(
       groupId,
       user.userId,
       targetUserId,
       dto,
     );
+    return {
+      status: 'success',
+      message: '역할이 변경되었습니다.',
+      data: member,
+    };
+  }
+
+  @UseGuards(GroupMemberGuard)
+  @Post('me/leave')
+  @ApiMembers.leaveSelf()
+  async leaveSelf(
+    @Param('groupId', ParseIntPipe) groupId: number,
+    @User() user: AuthenticatedUser,
+  ): Promise<ApiResponseDto<MemberResponseDto>> {
+    const member = await this.membersService.updateMemberStatus(
+      groupId,
+      user.userId,
+      MemberAction.LEFT,
+      user.userId,
+    );
+    return { status: 'success', message: '그룹을 탈퇴했습니다.', data: member };
   }
 }

--- a/src/member/member.repository.ts
+++ b/src/member/member.repository.ts
@@ -95,4 +95,14 @@ export class MemberRepository {
       },
     });
   }
+
+  async countManagers(groupId: number): Promise<number> {
+    return this.prisma.userGroup.count({
+      where: {
+        groupId,
+        role: UserGroupRole.MANAGER,
+        status: MembershipStatus.APPROVED,
+      },
+    });
+  }
 }

--- a/src/member/member.swagger.ts
+++ b/src/member/member.swagger.ts
@@ -11,6 +11,7 @@ import {
 import { MemberResponseDto } from './dto/member-response.dto';
 import { JoinMemberRequestDto } from './dto/join-member-request.dto';
 import { UpdateMemberStatusDto } from './dto/update-member-status.dto';
+import { UpdateMemberRoleDto } from './dto/update-member-role.dto';
 import { MemberAction } from './member-action.enum';
 
 const unauthorizedResponse = () =>
@@ -221,6 +222,34 @@ export const ApiMembers = {
       unauthorizedResponse(),
       forbiddenResponse('권한이 없습니다.'),
       conflictResponse('처리할 수 없는 요청입니다.'),
+    ),
+  updateRole: () =>
+    applyDecorators(
+      ApiOperation({ summary: '멤버 역할 변경 (매니저 전용)' }),
+      ApiParam({ name: 'groupId', type: Number, description: '그룹 ID' }),
+      ApiParam({
+        name: 'id',
+        type: Number,
+        description: '대상 멤버의 사용자 ID',
+      }),
+      ApiBody({
+        type: UpdateMemberRoleDto,
+        examples: {
+          promote: {
+            summary: '멤버 → 매니저 승격',
+            value: { role: 'MANAGER' },
+          },
+          demote: { summary: '매니저 → 멤버 강등', value: { role: 'MEMBER' } },
+        },
+      }),
+      ApiResponseWithData(Object, 200, '역할 변경 성공', {
+        message: '역할이 변경되었습니다.',
+        member: {},
+      }),
+      unauthorizedResponse(),
+      forbiddenResponse('권한이 없습니다.'),
+      conflictResponse('마지막 매니저의 역할은 변경할 수 없습니다.'),
+      badRequestResponse(),
     ),
 };
 export function MemberSwagger() {


### PR DESCRIPTION
관련 이슈
- #82 

📝 제목
- 멤버 역할 변경 기능 추가 및 관련 API 구현
<!-- [작업 유형] 작업 내용 요약 (ex: [Feature] 회원가입 API 개발) -->

📋 작업 내용
- [ ]  멤버 역할(MEMBER/MANAGER) 변경 API 추가
- [ ] 서비스에 updateMemberRole 메서드 구현: 본인 역할 변경 금지, APPROVED 멤버만 허용, 마지막 매니저 강등 방지
- [ ] 레포지토리에 countManagers(groupId) 메서드 추가

🔧 기술 변경
-
 <!-- 새로운 모듈/패키지 추가 -->
 <!-- 폴더/파일 구조 변경 -->

🚀 테스트 사항(선택)
-
 <!--기능 테스트 완료 -->
 <!--API(Postman/Swagger) 테스트 -->
 <!-- 예외 처리 확인 -->

## 💬 리뷰 요구사항 (선택)  
<!-- 리뷰 요청 사항을 여기에 적어주세요 (선택사항) -->
