### PR TITLE
fix: (#119) memberCount에 pending 상태 유저 제거

### DIFF
--- a/src/groups/groups.repository.ts
+++ b/src/groups/groups.repository.ts
@@ -50,7 +50,11 @@ export class GroupsRepository {
     return this.prisma.group.findMany({
       orderBy: { createdAt: 'desc' },
       include: {
-        _count: { select: { userGroups: true } },
+        _count: {
+          select: {
+            userGroups: { where: { status: MembershipStatus.APPROVED } },
+          },
+        },
       },
     });
   }


### PR DESCRIPTION
관련 이슈
-
#119 

📝 제목
-
[fix] memberCount에 pending 상태 유저 제거

📋 작업 내용
-
- [ ]  `GroupsRepository.findAllGroups` 수정 
- [ ]  불필요한 코드 정리 
- [ ]  리팩토링 (필요 시) 

🔧 기술 변경
-
 <!-- 새로운 모듈/패키지 추가 -->
 <!-- 폴더/파일 구조 변경 -->

🚀 테스트 사항(선택)
-
- 그룹 21에 `PENDING` 1명, `APPROVED` 2명 생성
- 그룹 목록/상세 조회 시 `memberCount === 2` 확인
