### PR TITLE
fix: (#121) 비멤버의 그룹 게시물작성이 허용됨

### DIFF
--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -24,6 +24,7 @@ import { PostWriteResponseDto } from './dto/responses/post-write-response.dto';
 import { PostResponseDto } from './dto/responses/post-response.dto';
 import { ApiPosts } from './post.swagger';
 import { PostsService } from './posts.service';
+import { GroupMemberGuard } from 'src/member/guards/group-member.guard';
 
 @ApiBearerAuth('access-token')
 @Controller('groups/:groupId/posts')
@@ -33,6 +34,7 @@ export class PostsController {
 
   @Post()
   @UseInterceptors(FileInterceptor('postImage'))
+  @UseGuards(CustomJwtAuthGuard, GroupMemberGuard)
   @ApiConsumes('multipart/form-data')
   @ApiPosts.create()
   async createPost(

--- a/src/posts/posts.module.ts
+++ b/src/posts/posts.module.ts
@@ -4,9 +4,10 @@ import { PostsRepository } from './posts.repository';
 import { PostsService } from './posts.service';
 import { S3Module } from 'src/s3/s3.module';
 import { PostLikesModule } from 'src/likes/post-likes.module';
+import { MemberModule } from 'src/member/member.module';
 
 @Module({
-  imports: [S3Module, forwardRef(() => PostLikesModule)],
+  imports: [S3Module, forwardRef(() => PostLikesModule), MemberModule],
   controllers: [PostsController],
   providers: [PostsService, PostsRepository],
   exports: [PostsRepository],


### PR DESCRIPTION
관련 이슈
-
#121 

📝 제목
-
[fix] 비멤버의 그룹 게시물 작성 제한

📋 작업 내용
-
- [ ]  GroupMemberGuard 추가로 권한 검증 강화

🔧 기술 변경
-
- 게시물 작성 컨트롤러에 @UseGuards(CustomJwtAuthGuard, GroupMemberGuard) 추가

🚀 테스트 사항(선택)
-
- 기능 테스트 완료 - 비멤버 게시물 작성 차단 확인
- API(Postman/Swagger) 테스트 완료