### PR TITLE
fix: (#123)존재하지 않는 그룹 조회 시 404 에러 응답 추가

### DIFF
--- a/src/posts/posts.module.ts
+++ b/src/posts/posts.module.ts
@@ -5,9 +5,15 @@ import { PostsService } from './posts.service';
 import { S3Module } from 'src/s3/s3.module';
 import { PostLikesModule } from 'src/likes/post-likes.module';
 import { MemberModule } from 'src/member/member.module';
+import { GroupsModule } from 'src/groups/groups.module';
 
 @Module({
-  imports: [S3Module, forwardRef(() => PostLikesModule), MemberModule],
+  imports: [
+    S3Module,
+    forwardRef(() => PostLikesModule),
+    MemberModule,
+    GroupsModule,
+  ],
   controllers: [PostsController],
   providers: [PostsService, PostsRepository],
   exports: [PostsRepository],

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -13,6 +13,7 @@ import { CreatePostRequestDto } from './dto/requests/create-post.dto';
 import { UpdatePostRequestDto } from './dto/requests/update-post.dto';
 
 import { CreatePostData, Post, PostSummary } from './interfaces/post.interface';
+import { GroupsRepository } from 'src/groups/groups.repository';
 
 @Injectable()
 export class PostsService {
@@ -20,6 +21,7 @@ export class PostsService {
     private readonly postsRepository: PostsRepository,
     private readonly s3Service: S3Service,
     private readonly postLikesRepository: PostLikesRepository,
+    private readonly groupRepostirory: GroupsRepository,
   ) {}
 
   private toImageUrl(key?: string | null): string | null {
@@ -67,6 +69,10 @@ export class PostsService {
     groupId: number,
     userId: number,
   ): Promise<PostSummary[]> {
+    const groups = await this.groupRepostirory.findGroupById(groupId);
+    if (!groups) {
+      throw new NotFoundException(`그룹 ID ${groupId}를 찾을 수 없습니다.`);
+    }
     const postsWithCounts =
       await this.postsRepository.findPostsWithCommentsCount(groupId);
 


### PR DESCRIPTION
관련 이슈
-
#이슈번호 (예: #5)

📝 제목
-
[Fix] 존재하지 않는 그룹 Post 조회 시 404 에러 반환 처리

📋 작업 내용
-
- [ ]  기능 추가/수정 - 그룹 존재 여부 검증 로직 추가

🔧 기술 변경
-
- 새로운 모듈 추가: PostModule에 GroupsModule 의존성 추가 
- 에러 처리 개선: NotFoundException을 통한 404 응답 처리

🚀 테스트 사항(선택)
-
- 기능 테스트 완료 - 존재하지 않는 그룹 ID로 Post 조회 시 404 에러 확인
- API(Postman) 테스트 - 404 Not Found 응답 및 에러 메시지 확인
