### PR TITLE
feat: (#125) GroupMemberGuard 적용으로 작성/수정/삭제 제한

### DIFF
--- a/src/comments/comments.controller.ts
+++ b/src/comments/comments.controller.ts
@@ -15,6 +15,7 @@ import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { plainToInstance } from 'class-transformer';
 import { Request } from 'express';
 import { CustomJwtAuthGuard } from 'src/auth/guards/access.guard';
+import { GroupMemberGuard } from 'src/member/guards/group-member.guard';
 import { ApiResponseDto } from '../common/dto/api-response.dto';
 import { ApiComments } from './comment.swagger';
 import { CommentsService } from './comments.service';
@@ -29,6 +30,7 @@ import { ResCommentDto } from './dto/responses/res-comment.dto';
 export class CommentsController {
   constructor(private readonly commentsService: CommentsService) {}
 
+  @UseGuards(GroupMemberGuard)
   @Post()
   @ApiComments.create()
   async createComment(
@@ -75,6 +77,7 @@ export class CommentsController {
     };
   }
 
+  @UseGuards(GroupMemberGuard)
   @Patch(':id')
   @ApiComments.update()
   async updateComment(
@@ -102,6 +105,7 @@ export class CommentsController {
     };
   }
 
+  @UseGuards(GroupMemberGuard)
   @Delete(':id')
   @ApiComments.delete()
   async deleteComment(

--- a/src/comments/comments.module.ts
+++ b/src/comments/comments.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
+import { MemberModule } from 'src/member/member.module';
 import { PostsModule } from 'src/posts/posts.module';
 import { CommentsController } from './comments.controller';
 import { CommentsRepository } from './comments.repository';
 import { CommentsService } from './comments.service';
 
 @Module({
-  imports: [PostsModule],
+  imports: [PostsModule, MemberModule],
   providers: [CommentsService, CommentsRepository],
   controllers: [CommentsController],
   exports: [CommentsRepository],


### PR DESCRIPTION
관련 이슈
-
- #125 

📝 제목
-
[Feature] 댓글에 GroupMemberGuard 적용

📋 작업 내용
-
- [x]   CommentsController에 create/update/delete에 Guard 적용
- [x]   Swagger 문서 수정: create/update/delete에서 403 응답 추가

🔧 기술 변경
-
없음

🚀 테스트 사항(선택)
-
그룹 멤버/매니저: 댓글 작성/수정/삭제 성공
비멤버/대기/차단 상태: 403 응답 확인
