### PR TITLE
feat: (#130) 공지게시판 기능 추가

### DIFF
--- a/src/posts/dto/requests/create-post.dto.ts
+++ b/src/posts/dto/requests/create-post.dto.ts
@@ -1,5 +1,6 @@
-import { IsString, IsNotEmpty, MaxLength } from 'class-validator';
+import { IsString, IsNotEmpty, MaxLength, IsEnum } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { PostCategory } from '@prisma/client';
 
 export class CreatePostRequestDto {
   @ApiProperty({ example: '게시물 제목', description: '게시물 제목' })
@@ -12,4 +13,13 @@ export class CreatePostRequestDto {
   @IsString()
   @IsNotEmpty()
   content: string;
+
+  @ApiProperty({
+    example: PostCategory.NORMAL,
+    enum: PostCategory,
+    description: '게시물 유형',
+  })
+  @IsEnum(PostCategory)
+  @IsNotEmpty()
+  category: PostCategory;
 }

--- a/src/posts/dto/requests/update-post.dto.ts
+++ b/src/posts/dto/requests/update-post.dto.ts
@@ -1,5 +1,6 @@
-import { IsOptional, IsString, MaxLength } from 'class-validator';
+import { IsEnum, IsOptional, IsString, MaxLength } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
+import { PostCategory } from '@prisma/client';
 
 export class UpdatePostRequestDto {
   @ApiPropertyOptional({ example: '수정된 제목' })
@@ -12,4 +13,9 @@ export class UpdatePostRequestDto {
   @IsOptional()
   @IsString()
   content?: string;
+
+  @ApiPropertyOptional({ example: '수정된 게시물 유형' })
+  @IsOptional()
+  @IsEnum(PostCategory)
+  category?: PostCategory;
 }

--- a/src/posts/dto/responses/post-response.dto.ts
+++ b/src/posts/dto/responses/post-response.dto.ts
@@ -33,10 +33,6 @@ export class PostResponseDto {
   @Expose()
   updatedAt: Date | null;
 
-  @ApiProperty({ example: PostCategory.NORMAL, description: '분류' })
-  @Expose()
-  category: PostCategory;
-
   @ApiProperty({ example: '제목', description: '게시물 제목' })
   @Expose()
   title: string;
@@ -44,6 +40,14 @@ export class PostResponseDto {
   @ApiProperty({ example: '본문 내용', description: '게시물 내용' })
   @Expose()
   content: string;
+
+  @ApiProperty({
+    example: PostCategory.NORMAL,
+    enum: PostCategory,
+    description: '분류',
+  })
+  @Expose()
+  category: PostCategory;
 
   @ApiProperty({
     example:

--- a/src/posts/dto/responses/post-write-response.dto.ts
+++ b/src/posts/dto/responses/post-write-response.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { PostCategory } from '@prisma/client';
 import { Expose } from 'class-transformer';
 
 export class PostWriteResponseDto {
@@ -21,6 +22,14 @@ export class PostWriteResponseDto {
   @ApiProperty({ example: '본문', description: '게시물 내용' })
   @Expose()
   content: string;
+
+  @ApiProperty({
+    example: PostCategory.ANNOUNCEMENT,
+    description: '게시물 유형',
+    enum: PostCategory,
+  })
+  @Expose()
+  category: PostCategory;
 
   @ApiProperty({ example: '2025-07-04T10:00:00Z', description: '작성일' })
   @Expose()

--- a/src/posts/interfaces/post.interface.ts
+++ b/src/posts/interfaces/post.interface.ts
@@ -57,6 +57,7 @@ export interface PostImage {
 export interface CreatePostData {
   title: string;
   content: string;
+  category: PostCategory;
   groupId: number;
   userId: number;
 }

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -14,6 +14,8 @@ import { UpdatePostRequestDto } from './dto/requests/update-post.dto';
 
 import { CreatePostData, Post, PostSummary } from './interfaces/post.interface';
 import { GroupsRepository } from 'src/groups/groups.repository';
+import { MemberRepository } from 'src/member/member.repository';
+import { PostCategory, UserGroupRole } from '@prisma/client';
 
 @Injectable()
 export class PostsService {
@@ -22,7 +24,15 @@ export class PostsService {
     private readonly s3Service: S3Service,
     private readonly postLikesRepository: PostLikesRepository,
     private readonly groupRepostirory: GroupsRepository,
+    private readonly memberRepository: MemberRepository,
   ) {}
+
+  private async ensureManagerOrAdmin(groupId: number, userId: number) {
+    const member = await this.memberRepository.findGroupMember(groupId, userId);
+    if (!member || member.role === UserGroupRole.MEMBER) {
+      throw new ForbiddenException('공지 작성/변경은 관리자만 가능합니다');
+    }
+  }
 
   private toImageUrl(key?: string | null): string | null {
     return key ? this.s3Service.getFileUrl(key) : null;
@@ -34,8 +44,11 @@ export class PostsService {
     userId: number,
     fileToUpload?: Express.Multer.File,
   ): Promise<Post> {
-    let uploadedImageKey: string | undefined;
+    if (createPostDto.category === PostCategory.ANNOUNCEMENT) {
+      await this.ensureManagerOrAdmin(groupId, userId);
+    }
 
+    let uploadedImageKey: string | undefined;
     try {
       if (fileToUpload) {
         uploadedImageKey = await this.s3Service.uploadFile(fileToUpload, {
@@ -47,6 +60,7 @@ export class PostsService {
       const createData: CreatePostData = {
         title: createPostDto.title,
         content: createPostDto.content,
+        category: createPostDto.category,
         groupId,
         userId,
       };
@@ -123,6 +137,10 @@ export class PostsService {
     }
     if (post.userId !== userId) {
       throw new ForbiddenException('이 게시물을 수정할 권한이 없습니다.');
+    }
+
+    if (updatePostDto.category !== undefined) {
+      await this.ensureManagerOrAdmin(post.groupId, userId);
     }
 
     return this.postsRepository.updatePost(postId, {


### PR DESCRIPTION
관련 이슈
-
#130 

📝 제목
-
[feat] 게시물 공지/카테고리 권한 검증 추가

📋 작업 내용
-
- [ ]  공지 생성 시 서비스 계층에서 매니저 권한 검사 추가
- [ ]  업데이트에서 category 필드가 요청에 있을 때만 매니저 권한 검사
- [ ]  DTO: Create/Update에서 PostCategory enum 검증 강화(@IsEnum, @IsDefined) 

🔧 기술 변경
-
- 서비스: `ensureManager(...)` 메서드 추가(멤버 null 또는 MEMBER면 403)

🚀 테스트 사항(선택)
-
- Manager 계정: 공지 생성/변경 200
- Member 계정: 공지 생성/변경 403