### PR TITLE
chore: (#137) Prisma 마이그레이션 스텝 추가

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,8 +58,16 @@ jobs:
     env:
       DOCKER_IMAGE_NAME: ${{ secrets.DOCKER_USERNAME }}/modgu
       CONTAINER_NAME: modonggu-backend # 컨테이너 이름
+      DATABASE_URL: ${{ secrets.DATABASE_URL_PROD }}
 
     steps:
+      - name: Run Prisma Migrate Deploy
+        run: |
+          docker run --rm \
+          -e DATABASE_URL=$DATABASE_URL \
+          node:20 \
+          sh -c "npm install prisma --no-save && npx prisma migrate deploy"
+
       - name: Pull latest Docker image
         run: |
           echo "최신 도커 이미지 Pull 중..."

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,12 +61,16 @@ jobs:
       DATABASE_URL: ${{ secrets.DATABASE_URL_PROD }}
 
     steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
       - name: Run Prisma Migrate Deploy
         run: |
           docker run --rm \
-          -e DATABASE_URL=$DATABASE_URL \
+          -e DATABASE_URL="$DATABASE_URL" \
+          -v "${{ github.workspace }}":/app -w /app \
           node:20 \
-          sh -c "npm install prisma --no-save && npx prisma migrate deploy"
+          sh -c 'npm install prisma@$(node -p "require(\"./package.json\").devDependencies.prisma") --no-save && npx prisma migrate deploy'
 
       - name: Pull latest Docker image
         run: |


### PR DESCRIPTION
관련 이슈
-
#137 

📝 제목
-
[Chore] CI/CD 파이프라인에 Prisma 마이그레이션 스텝 추가

📋 작업 내용
-

- [x] Prisma 마이그레이션 자동 적용 스텝 추가
- [x] 배포 시 임시 node 컨테이너를 통해 `prisma migrate deploy` 실행
- [x] 운영 이미지에는 prisma CLI 불필요 → 컨테이너 경량화 유지
- [x] DATABASE_URL은 GitHub Secrets에서 주입

🔧 기술 변경
-
GitHub Actions 워크플로우 수정
docker run 기반 임시 컨테이너에서 마이그레이션 실행

🚀 테스트 사항(선택)
-
 develop 브랜치 배포 시 마이그레이션 정상 동작 확인 예정
