### PR TITLE
feat: (#139) 새 게시물 알림 로직 구현

### DIFF
--- a/src/member/member.repository.ts
+++ b/src/member/member.repository.ts
@@ -50,6 +50,22 @@ export class MemberRepository {
     });
   }
 
+  // 본인 제외 그룹 내 멤버 가져오기
+  async findMemberIdsByGroup(
+    groupId: number,
+    excludeUserId: number,
+  ): Promise<number[]> {
+    const memberIds = await this.prisma.userGroup.findMany({
+      where: {
+        groupId,
+        status: MembershipStatus.APPROVED,
+        userId: { not: excludeUserId },
+      },
+      select: { userId: true },
+    });
+    return memberIds.map((m) => m.userId);
+  }
+
   async findManagersByGroup(groupId: number): Promise<{ userId: number }[]> {
     return this.prisma.userGroup.findMany({
       where: {

--- a/src/notifications/notifications.mapper.ts
+++ b/src/notifications/notifications.mapper.ts
@@ -9,7 +9,8 @@ export function toNotificationResponseDto(entity: {
     type: NotificationType;
     message: string;
     senderId: number | null;
-    groupId: number | null;
+    groupId?: number | null;
+    postId?: number | null;
     createdAt: Date;
   };
 }): NotificationResponseDto {
@@ -24,6 +25,18 @@ export function toNotificationResponseDto(entity: {
         createdAt: notification.createdAt,
         isRead,
         payload: { groupId: notification.groupId! },
+      };
+    case NotificationType.NEW_POST_IN_GROUP:
+      return {
+        id: notification.id,
+        type: notification.type,
+        message: notification.message,
+        createdAt: notification.createdAt,
+        isRead,
+        payload: {
+          groupId: notification.groupId!,
+          postId: notification.postId!,
+        },
       };
     default:
       throw new InternalServerErrorException(

--- a/src/notifications/notifications.repository.ts
+++ b/src/notifications/notifications.repository.ts
@@ -1,5 +1,8 @@
 import { Injectable } from '@nestjs/common';
-import { NotificationType } from '@prisma/client';
+import {
+  NotificationType,
+  Notification as PrismaNotification,
+} from '@prisma/client';
 import { PrismaService } from 'src/prisma/prisma.service';
 
 @Injectable()
@@ -10,7 +13,7 @@ export class NotificationsRepository {
     groupId: number,
     message: string,
     managerIds: number[],
-  ): Promise<{ isRead: boolean; notification: any }> {
+  ): Promise<{ isRead: boolean; notification: PrismaNotification }> {
     const notification = await this.prisma.notification.create({
       data: {
         type: NotificationType.NEW_JOIN_REQUEST,
@@ -18,6 +21,34 @@ export class NotificationsRepository {
         groupId,
         message,
         recipients: { create: managerIds.map((userId) => ({ userId })) },
+      },
+    });
+
+    return {
+      isRead: false,
+      notification,
+    };
+  }
+
+  async createNewPost(
+    senderId: number,
+    groupId: number,
+    postId: number,
+    message: string,
+    recipientIds: number[],
+  ): Promise<{ isRead: boolean; notification: PrismaNotification }> {
+    const notification = await this.prisma.notification.create({
+      data: {
+        type: NotificationType.NEW_POST_IN_GROUP,
+        senderId,
+        groupId,
+        postId,
+        message,
+        recipients: {
+          create: recipientIds.map((userId) => ({
+            userId,
+          })),
+        },
       },
     });
 
@@ -49,6 +80,7 @@ export class NotificationsRepository {
         message: string;
         senderId: number | null;
         groupId: number | null;
+        postId: number | null;
         createdAt: Date;
       };
     }[]
@@ -65,6 +97,7 @@ export class NotificationsRepository {
             message: true,
             senderId: true,
             groupId: true,
+            postId: true,
             createdAt: true,
           },
         },

--- a/src/notifications/types/notification-response.type.ts
+++ b/src/notifications/types/notification-response.type.ts
@@ -10,7 +10,7 @@ type BaseNotification = {
 
 type NotificationPayloadMap = {
   [NotificationType.NEW_JOIN_REQUEST]: { groupId: number };
-  [NotificationType.NEW_POST_IN_GROUP]: { groupId: number; postId: number };
+  [NotificationType.NEW_POST_IN_GROUP]: { postId: number };
 };
 
 export type NotificationResponseDto =

--- a/src/posts/posts.module.ts
+++ b/src/posts/posts.module.ts
@@ -1,11 +1,12 @@
 import { Module, forwardRef } from '@nestjs/common';
+import { GroupsModule } from 'src/groups/groups.module';
+import { PostLikesModule } from 'src/likes/post-likes.module';
+import { MemberModule } from 'src/member/member.module';
+import { NotificationsModule } from 'src/notifications/notifications.module';
+import { S3Module } from 'src/s3/s3.module';
 import { PostsController } from './posts.controller';
 import { PostsRepository } from './posts.repository';
 import { PostsService } from './posts.service';
-import { S3Module } from 'src/s3/s3.module';
-import { PostLikesModule } from 'src/likes/post-likes.module';
-import { MemberModule } from 'src/member/member.module';
-import { GroupsModule } from 'src/groups/groups.module';
 
 @Module({
   imports: [
@@ -13,6 +14,7 @@ import { GroupsModule } from 'src/groups/groups.module';
     forwardRef(() => PostLikesModule),
     MemberModule,
     GroupsModule,
+    NotificationsModule,
   ],
   controllers: [PostsController],
   providers: [PostsService, PostsRepository],


### PR DESCRIPTION
관련 이슈
-
- #139 

📝 제목
-
[Feature] 그룹 내 새 게시물 알림 기능 추가

📋 작업 내용
-
- [x] `PostsService`에서 게시물 생성 DB 저장 후 알림 호출 추가 (실패 시 warn 로그)
- [x]  `NotificationsService`에 새 게시물 알림 처리 로직(notifyNewPost) 추가
- [x]  `NotificationsRepository`에 새 게시물 알림 저장 메서드 구현
- [x]  `MemberRepository`에서 작성자를 제외한 그룹 멤버 ID를 조회하는 findMemberIdsByGroup 메서드 추가
- [x]  알림 매퍼에 새 게시물 타입 추가

🔧 기술 변경
-
새로운 알림 타입(NEW_POST_IN_GROUP) 추가
PostsService ↔ NotificationsService 간 의존 관계 확장
알림 실시간 전송(SSE) 로직에서 새 게시물 알림 신호 반영

🚀 테스트 사항(선택)
-
게시물 생성 시 알림 DB 저장 및 실시간 전송 확인
작성자는 알림 제외되는지 확인 완료
알림 목록 조회 시 정상적으로 payload(postId, groupId) 반환 확인

## 💬 리뷰 요구사항 (선택)  
<!-- 리뷰 요청 사항을 여기에 적어주세요 (선택사항) -->
