### PR TITLE
feat: (#146) 사용자 이름 변경 기능 추가

### DIFF
--- a/prisma/migrations/20250922063014_add_name_changed_at/migration.sql
+++ b/prisma/migrations/20250922063014_add_name_changed_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."users" ADD COLUMN     "name_changed_at" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,6 +37,7 @@ model User {
   password              String             @db.VarChar(60)
   name                  String             @db.VarChar(50)
   profileImgPath        String?            @map("profile_img_path") @db.VarChar(255)
+  nameChangedAt         DateTime?          @map("name_changed_at")
   createdAt             DateTime           @default(now()) @map("created_at")
   comments              Comment[]
   postLikes             PostLike[]

--- a/src/users/dto/requests/update-profile.dto.ts
+++ b/src/users/dto/requests/update-profile.dto.ts
@@ -1,0 +1,8 @@
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+
+export class UpdateNameDto {
+  @IsString()
+  @MaxLength(50)
+  @IsNotEmpty({ message: 'name은 빈 문자열을 허용하지 않습니다.' })
+  name: string;
+}

--- a/src/users/dto/responses/user-profile.dto.ts
+++ b/src/users/dto/responses/user-profile.dto.ts
@@ -20,4 +20,7 @@ export class UserProfileDto {
     description: '프로필 이미지 URL',
   })
   profileImageUrl: string;
+
+  @Expose()
+  nameChangedAt?: string | null;
 }

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,25 +1,28 @@
 import {
   BadRequestException,
+  Body,
   Controller,
   Delete,
   Get,
+  ParseEnumPipe,
   Patch,
+  Query,
   UploadedFile,
   UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { MembershipStatus } from '@prisma/client';
 import { User } from 'src/auth/user.decorator';
 import { ApiResponseDto } from 'src/common/dto/api-response.dto';
 import { CustomJwtAuthGuard } from '../auth/guards/access.guard';
 import { AuthenticatedUserResponse } from '../auth/interfaces/authenticated-user-response.interface';
-import { UserProfileDto } from './dto/responses/user-profile.dto';
+import { UpdateNameDto } from './dto/requests/update-profile.dto';
 import { UserGroupSummaryDto } from './dto/responses/user-group-summary.dto';
+import { UserProfileDto } from './dto/responses/user-profile.dto';
 import { UsersService } from './users.service';
 import { ApiUsers } from './users.swagger';
-import { MembershipStatus } from '@prisma/client';
-import { ParseEnumPipe, Query } from '@nestjs/common';
 
 @ApiTags('Users')
 @Controller('users')
@@ -39,6 +42,23 @@ export class UsersController {
       status: 'success',
       message: '내 정보 조회 성공',
       data: userProfileData,
+    };
+  }
+
+  @Patch('me')
+  async updateMyName(
+    @Body() updateNameDto: UpdateNameDto,
+    @User() user: AuthenticatedUserResponse,
+  ): Promise<ApiResponseDto<UserProfileDto>> {
+    const updatedUser = await this.usersService.updateProfileName(
+      user.userId,
+      updateNameDto.name,
+    );
+
+    return {
+      status: 'success',
+      message: '이름이 성공적으로 변경되었습니다.',
+      data: updatedUser,
     };
   }
 


### PR DESCRIPTION
관련 이슈
-
- #146 

📝 제목
-
[Feature] 사용자 이름 변경 기능 추가

📋 작업 내용
-
이름 업데이트 API 개발
- [x] PATCH /users/me 엔드포인트 추가
- [x] UpdateNameDto 작성 및 유효성 검사 validator 적용
- [x] 동일한 이름으로 변경 시 업데이트 처리하지 않고 기존 데이터 반환
- [x] 최근 변경일로부터 30일 이내에는 변경 불가하도록 예외 처리(BadRequestException)) 

UserProfileDto 개선
- [x] nameChangedAt 응답 필드 조건부 노출 적용
조회 API(/users/me)에서는 노출
업데이트/이미지 관련 API 응답에서는 미노출

🔧 기술 변경
-
class-transformer 옵션 exposeUnsetFields: false 적용
DTO Date 응답 타입을 string | null로 정리

🚀 테스트 사항(선택)
-

- PATCH /users/me 정상 동작 확인
  - 새로운 이름 → 성공 응답 (nameChangedAt 미포함)
  - 동일 이름 → 변경되지 않음, 기존 값 그대로 반환
  - 최근 30일 이내 재변경 → BadRequestException 발생

- GET /users/me 응답에 nameChangedAt 정상 포함
- 프로필 이미지 업데이트/리셋 시 nameChangedAt 미포함 확인

## 💬 리뷰 요구사항 (선택)  
nameChangedAt 조건부 노출(조회 시에만 포함) 방식이 합리적인지 검토 부탁드립니다.

동일한 이름 변경 시 "변경으로 취급하지 않음" 처리 로직이 적절한지 의견 부탁드립니다.
