### PR TITLE
infra: (#149) main/develop 브랜치 기반 배포 설정

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,9 +9,8 @@ on:
     branches:
       - main
       - develop
-
 jobs:
-  build-and-push-docker:
+  build-and-test:
     runs-on: ubuntu-latest
 
     steps:
@@ -30,8 +29,14 @@ jobs:
       - name: Lint & Build
         run: npm run lint && npm run build
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+  build-and-push-docker:
+    if: github.event_name == 'push'
+    needs: build-and-test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -45,34 +50,35 @@ jobs:
           context: .
           push: ${{ github.event_name == 'push' }}
           tags: |
-            ${{ secrets.DOCKER_USERNAME }}/modgu:latest
+            ${{ secrets.DOCKER_USERNAME }}/modgu:${{ github.ref_name }}
             ${{ secrets.DOCKER_USERNAME }}/modgu:${{ github.sha }}
 
-  ## deploy
-  deploy-to-ec2-self-hosted:
-    needs: build-and-push-docker # build-and-push-docker 작업이 완료된 후 실행
-    runs-on: [self-hosted, modgu-back-runner, linux, x64]
+  ## prod deploy
+  deploy-to-ec2-prod:
+    needs: build-and-push-docker
+    runs-on: [self-hosted, modgu-prod-runner]
 
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     env:
       DOCKER_IMAGE_NAME: ${{ secrets.DOCKER_USERNAME }}/modgu
-      CONTAINER_NAME: modonggu-backend # 컨테이너 이름
+      CONTAINER_NAME: modonggu-backend-prod
+      DOCKER_TAG: ${{ github.ref_name }}
 
     steps:
       - name: Pull latest Docker image
         run: |
           echo "최신 도커 이미지 Pull 중..."
-          docker pull $DOCKER_IMAGE_NAME:latest
+          docker pull $DOCKER_IMAGE_NAME:${DOCKER_TAG}
 
-      - name: Deploy to EC2 and Run Docker Container
+      - name: Deploy to Prod EC2 and Run Docker Container
         run: |
           echo "docker-compose 재시작..."
           cd /home/ubuntu/9term-main-back
           docker-compose down
           docker-compose up -d
-
-      - name: Check Container Status
+      - &check-container
+        name: Check Container Status
         run: |
           echo "--- 컨테이너 상태 확인 중 ---"
           sleep 20
@@ -85,3 +91,29 @@ jobs:
               echo "컨테이너가 실행 중이 아닙니다. 다시 확인하세요."
               exit 1
           fi
+
+  ## dev deploy
+  deploy-to-ec2-dev:
+    needs: build-and-push-docker
+    runs-on: [self-hosted, modgu-dev-runner]
+
+    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+
+    env:
+      DOCKER_IMAGE_NAME: ${{ secrets.DOCKER_USERNAME }}/modgu
+      CONTAINER_NAME: modonggu-backend-dev
+      DOCKER_TAG: ${{ github.ref_name }}
+
+    steps:
+      - name: Pull latest Docker image
+        run: |
+          echo "최신 도커 이미지 Pull 중..."
+          docker pull $DOCKER_IMAGE_NAME:${DOCKER_TAG}
+
+      - name: Deploy to dev EC2 and Run Docker Container
+        run: |
+          echo "docker-compose 재시작..."
+          cd /home/ubuntu/9term-main-back
+          docker-compose down
+          docker-compose up -d
+      - *check-container

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,31 +1,27 @@
 version: '3.8'
 
 services:
-
-  # 1. NestJS 
+  # 1. NestJS
   modonggu-backend:
     container_name: modonggu-backend
-    # build:
-    #   context: .
-    #   dockerfile: Dockerfile
-    image: kangsengmin/modgu:latest
+    image: kangsengmin/modgu:${DOCKER_TAG}
     ports:
-      - "8081:3000" # EC2 외부에서 접근할 포트
-    expose: 
-      - "3000"
-    env_file: 
+      - '8081:3000' # EC2 외부에서 접근할 포트
+    expose:
+      - '3000'
+    env_file:
       - ./.env
     restart: unless-stopped
     networks:
       - modonggu-net
- 
-  # 2. Nginx 
+
+  # 2. Nginx
   nginx:
     container_name: nginx
     image: nginx:latest
     ports:
-      - "80:80"
-      - "443:443"
+      - '80:80'
+      - '443:443'
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./nginx/conf.d:/etc/nginx/conf.d:ro
@@ -36,7 +32,7 @@ services:
     restart: unless-stopped
     networks:
       - modonggu-net
-    
+
   # 3. Certbot
   certbot:
     container_name: certbot
@@ -44,18 +40,21 @@ services:
     volumes:
       - ./certbot/conf:/etc/letsencrypt
       - ./certbot/www:/var/www/certbot
-    depends_on: 
+    depends_on:
       - nginx
     entrypoint: >
       /bin/sh -c "
-        certbot certonly --webroot -w /var/www/certbot -d api.modonggu.site \
-          --email ${EMAIL} --agree-tos --no-eff-email --rsa-key-size 4096 && \
-        while :; do certbot renew --webroot -w /var/www/certbot && sleep 12h; done
+        if [ ! -e /etc/letsencrypt/live/${DOMAIN}/fullchain.pem ]; then
+          certbot certonly --webroot -w /var/www/certbot -d ${DOMAIN} \
+            --email ${EMAIL} --agree-tos --no-eff-email --rsa-key-size 4096;
+        fi;
+        while :; do
+          certbot renew --webroot -w /var/www/certbot;
+          sleep 12h;
+        done
       "
-    environment:
-      - EMAIL=${EMAIL}
     networks:
-      - modonggu-net 
+      - modonggu-net
 networks:
   modonggu-net:
     driver: bridge


### PR DESCRIPTION
관련 이슈
-
- #149 

📝 제목
-
[Infra] main/develop 브랜치 기반 CI/CD 배포 설정

📋 작업 내용
-
- [ ]  main / develop 브랜치 push 시 각각 prod / dev 서버에 배포되도록 GitHub Actions 수정
- [ ]  Docker 이미지 태그를 latest → ${DOCKER_TAG} (브랜치명 기반) 으로 변경
- [ ]  Certbot 설정에서 도메인 하드코딩(api.modonggu.site) 제거, ${DOMAIN} 환경변수 사용
- [ ]  Certbot 최초 실행 시 certonly 후, 이후에는 renew 주기적 실행

🔧 기술 변경
-
- backend 서비스 이미지 태그 latest → 브랜치명 기반 분리
- certbot entrypoint 로직 변경 (if 조건 추가)

🚀 테스트 사항(선택)
-
- EC2(dev) 환경에서 docker-compose 수동 실행 시 컨테이너 정상 작동 확인
- certbot 컨테이너 최초 인증서 발급 및 renew 주기 실행 로그 확인