### PR TITLE
feat: (#154) 매니저에게 게시물 삭제 권한 부여

### DIFF
--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -191,6 +191,9 @@ export class PostsService {
     const isManager = member?.role === UserGroupRole.MANAGER;
 
     if (!isAuthor && !isManager) {
+      if (!member) {
+        throw new ForbiddenException('그룹 회원만 접근이 가능합니다');
+      }
       throw new ForbiddenException('이 게시물을 삭제할 권한이 없습니다.');
     }
 


### PR DESCRIPTION
관련 이슈
-
#154

📝 제목
-
[feat] 매니저에게 게시물 삭제 권한 부여

📋 작업 내용
-
- [ ]  게시물 삭제 시 매니저 권한 검증 로직 추가
- [ ]  PostsService의 deletePost 메서드에 작성자/매니저 권한 체크 구현

🔧 기술 변경
-
- 게시물 삭제 권한: 작성자 본인 OR 해당 그룹의 매니저

🚀 테스트 사항(선택)
-
- 작성자가 본인 게시물 삭제 가능 확인
- 매니저가 그룹 내 다른 사람 게시물 삭제 가능 확인

