### PR TITLE
refactor: (#164) OAuth 토큰 전달 방식을 Redirect로 변경

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -110,7 +110,7 @@ export class AuthController {
     res.cookie('refresh_token', result.refreshToken, this.getCookieOptions());
     const frontendUrl = this.configService.get<string>('FRONTEND_URL');
     res.redirect(
-      `${frontendUrl}/login/success?accessToken=${result.accessToken}`,
+      `${frontendUrl}/login/success#accessToken=${result.accessToken}`,
     );
   }
 
@@ -130,10 +130,9 @@ export class AuthController {
     const result = await this.authService.oauthLogin(req.user);
 
     res.cookie('refresh_token', result.refreshToken, this.getCookieOptions());
-
     const frontendUrl = this.configService.get<string>('FRONTEND_URL');
     res.redirect(
-      `${frontendUrl}/login/success?accessToken=${result.accessToken}`,
+      `${frontendUrl}/login/success#accessToken=${result.accessToken}`,
     );
   }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -68,17 +68,9 @@ export class AuthService {
   async oauthLogin(params: OAuthInput): Promise<{
     accessToken: string;
     refreshToken: string;
-    provider?: string;
-    providerId?: string;
   }> {
     const user = await this.oauthService.resolveUser(params);
-    const tokens = this.issueTokens(user);
-    const canSet = !user.password;
-    return {
-      ...tokens,
-      provider: canSet ? params.provider : undefined,
-      providerId: canSet ? params.providerId : undefined,
-    };
+    return this.issueTokens(user);
   }
 
   private issueTokens(user: User): {
@@ -91,7 +83,7 @@ export class AuthService {
       name: user.name,
     };
     const accessToken = this.jwtService.sign(payload, {
-      secret: this.configService.getOrThrow<string>('JWT_SECRET_KEY'),
+      secret: this.configService.getOrThrow<string>('JWT_ACCESS_SECRET'),
       expiresIn: this.configService.getOrThrow<string>('JWT_ACCESS_EXPIRES_IN'),
     });
     const refreshPayload = { sub: user.id };

--- a/src/auth/oauth.service.ts
+++ b/src/auth/oauth.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
 import { User } from '@prisma/client';
 import { UsersService } from 'src/users/users.service';
 import { OAuthInput } from './interfaces/oauth.interface';
@@ -18,7 +18,9 @@ export class OAuthService {
     if (account) {
       const user = await this.usersService.findUserById(account.userId);
       if (!user) {
-        throw new NotFoundException('연결된 사용자 정보를 찾을 수 없습니다.');
+        throw new InternalServerErrorException(
+          '연결된 사용자 정보를 찾을 수 없습니다.',
+        );
       }
       return user;
     }

--- a/src/auth/strategies/access.strategy.ts
+++ b/src/auth/strategies/access.strategy.ts
@@ -11,7 +11,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     // super는 부모 클래스의 생성자를 호출하는 메서드이다.
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(), // 요청 헤더에서 Bearer 토큰을 추출하는 메서드이다.
-      secretOrKey: configService.getOrThrow<string>('JWT_SECRET_KEY'), // env 파일에 있는 값을 가져온다.
+      secretOrKey: configService.getOrThrow<string>('JWT_ACCESS_SECRET'), // env 파일에 있는 값을 가져온다.
       // getOrThrow은 해당 키가 없으면 에러를 던진다.
     });
   }


### PR DESCRIPTION
관련 이슈
-
- #164 

📝 제목
-
[Refactor] OAuth 토큰 전달 방식을 Redirect로 변경

📋 작업 내용
-
- [x] AuthController
Google / Kakao OAuth 콜백 시 JSON 응답 대신 Redirect URL의 쿼리 파라미터를 통해 accessToken을 전달하도록 수정
/login/success 경로로 통합 리다이렉션 처리
- [x] AuthService
oauthLogin() 로직 단순화 및 반환 구조 정리
- [x] OAuthService
resolveUser() 예외 처리 수정
- [x] Swagger
302 Redirect 응답 추가 (redirectResponse() 추가)

🔧 기술 변경
-
없음

🚀 테스트 사항(선택)
-
- Google/Kakao OAuth 로그인 성공 시 프론트 /login/success로 리다이렉트 확인
- accessToken URL 파라미터로 정상 전달 확인
-  쿠키에 refresh_token 정상 세팅 확인
-  Swagger 문서에서 302 Redirect 응답 확인

## 💬 리뷰 요구사항 (선택)  
현재 Redirect 경로(/login/success)는 임시 설정 → 프론트와 최종 명세 통일 필요
프론트엔드의 토큰 저장 처리 방식(localStorage or Context) 재확인 필요