### PR TITLE
fix: prod/dev 컨테이너 이름 통일

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
 
     env:
       DOCKER_IMAGE_NAME: ${{ secrets.DOCKER_USERNAME }}/modgu
-      CONTAINER_NAME: modonggu-backend-prod
+      CONTAINER_NAME: modonggu-backend
       DOCKER_TAG: ${{ github.ref_name }}
 
     steps:
@@ -101,7 +101,7 @@ jobs:
 
     env:
       DOCKER_IMAGE_NAME: ${{ secrets.DOCKER_USERNAME }}/modgu
-      CONTAINER_NAME: modonggu-backend-dev
+      CONTAINER_NAME: modonggu-backend
       DOCKER_TAG: ${{ github.ref_name }}
 
     steps:


### PR DESCRIPTION
관련 이슈
-
- #149 

📋 작업 내용
-
- [x] prod/dev 서버의 docker-compose와 workflow 간 컨테이너 이름 불일치로 인해 컨테이너 상태 check가 실패하는 문제 수정.