### PR TITLE
refactor: (#171) Swagger 에러 응답 중간 래핑 제거 및 공통 헬퍼 추가

### DIFF
--- a/src/comments/comment.swagger.ts
+++ b/src/comments/comment.swagger.ts
@@ -6,10 +6,27 @@ import {
   ApiResponse,
   getSchemaPath,
 } from '@nestjs/swagger';
+import {
+  apiErrorResponse,
+  apiErrorResponses,
+} from 'src/common/swagger/response.helper';
 import { ApiResponseDto } from '../common/dto/api-response.dto';
 import { ResCommentDto } from './dto/responses/res-comment.dto';
 
-// 공통 Unauthorized
+// 예외 응답 예시
+const badRequestExamples = {
+  InvalidNestedReply: {
+    message: '대댓글에는 답글을 달 수 없습니다.',
+    error: 'Bad Request',
+    statusCode: 400,
+  },
+  ContentRequired: {
+    message: ['content must be a string', '댓글 내용은 필수입니다.'],
+    error: 'Bad Request',
+    statusCode: 400,
+  },
+};
+
 const unauthorizedExamples = {
   TokenExpired: {
     message: '토큰이 만료되었습니다. 다시 로그인해주세요.',
@@ -20,20 +37,6 @@ const unauthorizedExamples = {
     message: '유효하지 않은 토큰입니다.',
     error: 'Unauthorized',
     statusCode: 401,
-  },
-};
-
-// 공통 Not Found
-const notFoundExamples = {
-  PostNotFound: {
-    message: '존재하지 않는 게시글입니다.',
-    error: 'Not Found',
-    statusCode: 404,
-  },
-  CommentNotFound: {
-    message: '존재하지 않는 댓글입니다.',
-    error: 'Not Found',
-    statusCode: 404,
   },
 };
 
@@ -50,31 +53,18 @@ const forbiddenExamples = {
   },
 };
 
-// 래핑 함수
-const withUnauthorizedResponses = () =>
-  unauthorizedResponses(unauthorizedExamples);
-
-const withForbiddenResponses = (keys: (keyof typeof forbiddenExamples)[]) =>
-  ForbiddenResponses(
-    keys.reduce(
-      (obj, key) => {
-        obj[key] = forbiddenExamples[key];
-        return obj;
-      },
-      {} as Record<string, any>,
-    ),
-  );
-
-const withNotFoundResponses = (keys: (keyof typeof notFoundExamples)[]) =>
-  NotFoundResponses(
-    keys.reduce(
-      (obj, key) => {
-        obj[key] = notFoundExamples[key];
-        return obj;
-      },
-      {} as Record<string, any>,
-    ),
-  );
+const notFoundExamples = {
+  PostNotFound: {
+    message: '존재하지 않는 게시글입니다.',
+    error: 'Not Found',
+    statusCode: 404,
+  },
+  CommentNotFound: {
+    message: '존재하지 않는 댓글입니다.',
+    error: 'Not Found',
+    statusCode: 404,
+  },
+};
 
 // 성공 응답
 const ApiResponseWithData = <T extends Type<any>>(
@@ -182,99 +172,6 @@ const successResponseNoData = (message: string, status = 200) =>
     },
   });
 
-// 클라이언트 요청 오류 응답
-const badRequestResponse = () =>
-  ApiResponse({
-    status: 400,
-    description: '잘못된 요청 데이터',
-    content: {
-      'application/json': {
-        example: {
-          message: ['content must be a string', '댓글 내용은 필수입니다.'],
-          error: 'Bad Request',
-          statusCode: 400,
-        },
-      },
-    },
-  });
-
-const unauthorizedResponses = (examples: {
-  [key: string]: { message: string; error: string; statusCode: number };
-}) =>
-  ApiResponse({
-    status: 401,
-    description: '인증되지 않음 (JWT 토큰 없음 또는 유효하지 않음)',
-    content: {
-      'application/json': {
-        examples: Object.entries(examples).reduce(
-          (acc, [name, exValue]) => {
-            acc[name] = {
-              value: {
-                message: exValue.message,
-                error: exValue.error,
-                statusCode: exValue.statusCode,
-              },
-            };
-            return acc;
-          },
-          {} as { [key: string]: { value: any } },
-        ),
-      },
-    },
-  });
-
-// 인증 / 권한 관련 응답
-const ForbiddenResponses = (examples: {
-  [key: string]: { message: string; error: string; statusCode: number };
-}) =>
-  ApiResponse({
-    status: 403,
-    description: '권한 없음',
-    content: {
-      'application/json': {
-        examples: Object.entries(examples).reduce(
-          (acc, [name, exValue]) => {
-            acc[name] = {
-              value: {
-                message: exValue.message,
-                error: exValue.error,
-                statusCode: exValue.statusCode,
-              },
-            };
-            return acc;
-          },
-          {} as { [key: string]: { value: any } },
-        ),
-      },
-    },
-  });
-
-// 리소스 없음
-const NotFoundResponses = (examples: {
-  [key: string]: { message: string; error: string; statusCode: number };
-}) =>
-  ApiResponse({
-    status: 404,
-    description: '요청한 리소스를 찾을 수 없음',
-    content: {
-      'application/json': {
-        examples: Object.entries(examples).reduce(
-          (acc, [name, exValue]) => {
-            acc[name] = {
-              value: {
-                message: exValue.message,
-                error: exValue.error,
-                statusCode: exValue.statusCode,
-              },
-            };
-            return acc;
-          },
-          {} as { [key: string]: { value: any } },
-        ),
-      },
-    },
-  });
-
 export const ApiComments = {
   create: () =>
     applyDecorators(
@@ -287,10 +184,18 @@ export const ApiComments = {
         201,
         '댓글이 성공적으로 생성되었습니다.',
       ),
-      badRequestResponse(),
-      withUnauthorizedResponses(),
-      withForbiddenResponses(['GroupMemberForbidden']),
-      withNotFoundResponses(['PostNotFound']),
+      apiErrorResponses(400, '잘못된 요청', badRequestExamples),
+      apiErrorResponses(401, '인증되지 않음', unauthorizedExamples),
+      apiErrorResponse(
+        403,
+        '권한 없음',
+        forbiddenExamples.GroupMemberForbidden,
+      ),
+      apiErrorResponse(
+        404,
+        '리소스를 찾을 수 없음',
+        notFoundExamples.PostNotFound,
+      ),
     ),
 
   update: () =>
@@ -301,18 +206,18 @@ export const ApiComments = {
         200,
         '댓글이 성공적으로 수정되었습니다.',
       ),
-      withForbiddenResponses(['GroupMemberForbidden', 'CommentForbidden']),
-      withUnauthorizedResponses(),
-      withNotFoundResponses(['PostNotFound', 'CommentNotFound']),
+      apiErrorResponses(403, '권한 없음', forbiddenExamples),
+      apiErrorResponses(401, '인증되지 않음', unauthorizedExamples),
+      apiErrorResponses(404, '리소스를 찾을 수 없음', notFoundExamples),
     ),
 
   delete: () =>
     applyDecorators(
       ApiOperation({ summary: '댓글 삭제', description: '댓글을 삭제합니다.' }),
       successResponseNoData('댓글이 성공적으로 삭제되었습니다.'),
-      withForbiddenResponses(['GroupMemberForbidden', 'CommentForbidden']),
-      withUnauthorizedResponses(),
-      withNotFoundResponses(['PostNotFound', 'CommentNotFound']),
+      apiErrorResponses(403, '권한 없음', forbiddenExamples),
+      apiErrorResponses(401, '인증되지 않음', unauthorizedExamples),
+      apiErrorResponses(404, '리소스를 찾을 수 없음', notFoundExamples),
     ),
 
   getList: () =>
@@ -368,7 +273,11 @@ export const ApiComments = {
           empty: [],
         },
       ),
-      withUnauthorizedResponses(),
-      withNotFoundResponses(['PostNotFound']),
+      apiErrorResponses(401, '인증되지 않음', unauthorizedExamples),
+      apiErrorResponse(
+        404,
+        '리소스를 찾을 수 없음',
+        notFoundExamples.PostNotFound,
+      ),
     ),
 };

--- a/src/comments/comment.swagger.ts
+++ b/src/comments/comment.swagger.ts
@@ -67,7 +67,7 @@ const notFoundExamples = {
 };
 
 // 성공 응답
-const ApiResponseWithData = <T extends Type<any>>(
+const apiResponseWithData = <T extends Type<any>>(
   model: T,
   status = 200,
   description = '요청이 성공적으로 처리되었습니다.',
@@ -91,7 +91,7 @@ const ApiResponseWithData = <T extends Type<any>>(
   );
 };
 
-const ApiResponseWithArrayData = <T extends Type<any>>(
+const apiResponseWithArrayData = <T extends Type<any>>(
   model: T,
   status = 200,
   description = '요청이 성공적으로 처리되었습니다.',
@@ -179,7 +179,7 @@ export const ApiComments = {
         summary: '댓글 생성',
         description: '게시글에 댓글을 생성합니다.',
       }),
-      ApiResponseWithData(
+      apiResponseWithData(
         ResCommentDto,
         201,
         '댓글이 성공적으로 생성되었습니다.',
@@ -201,7 +201,7 @@ export const ApiComments = {
   update: () =>
     applyDecorators(
       ApiOperation({ summary: '댓글 수정', description: '댓글을 수정합니다.' }),
-      ApiResponseWithData(
+      apiResponseWithData(
         ResCommentDto,
         200,
         '댓글이 성공적으로 수정되었습니다.',
@@ -235,7 +235,7 @@ export const ApiComments = {
         required: false,
         example: 1,
       }),
-      ApiResponseWithArrayData(
+      apiResponseWithArrayData(
         ResCommentDto,
         200,
         '댓글이 성공적으로 조회되었습니다.',

--- a/src/common/swagger/response.helper.ts
+++ b/src/common/swagger/response.helper.ts
@@ -1,0 +1,41 @@
+// swagger/response.ts
+import { ApiResponse } from '@nestjs/swagger';
+
+export interface SwaggerErrorExample {
+  message: string | string[];
+  error: string;
+  statusCode: number;
+}
+
+export const apiErrorResponse = (
+  status: number,
+  description: string,
+  example: SwaggerErrorExample,
+) =>
+  ApiResponse({
+    status,
+    description,
+    content: {
+      'application/json': {
+        example,
+      },
+    },
+  });
+
+// 예외가 여러 개일 때 → examples (dropdown)
+export const apiErrorResponses = (
+  status: number,
+  description: string,
+  examples: Record<string, SwaggerErrorExample>,
+) =>
+  ApiResponse({
+    status,
+    description,
+    content: {
+      'application/json': {
+        examples: Object.fromEntries(
+          Object.entries(examples).map(([key, value]) => [key, { value }]),
+        ),
+      },
+    },
+  });

--- a/src/posts/dto/requests/create-post.dto.ts
+++ b/src/posts/dto/requests/create-post.dto.ts
@@ -1,21 +1,24 @@
-import {
-  IsString,
-  IsNotEmpty,
-  MaxLength,
-  IsEnum,
-  IsOptional,
-} from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 import { PostCategory } from '@prisma/client';
+import {
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  MaxLength,
+} from 'class-validator';
 
 export class CreatePostRequestDto {
-  @ApiProperty({ example: '게시물 제목', description: '게시물 제목' })
+  @ApiProperty({ example: '첫 번째 글', description: '게시물 제목' })
   @IsString()
   @IsNotEmpty()
   @MaxLength(255)
   title: string;
 
-  @ApiProperty({ example: '본문 내용', description: '게시물 본문' })
+  @ApiProperty({
+    example: '안녕하세요! 본문 내용입니다. ',
+    description: '게시물 본문',
+  })
   @IsString()
   @IsNotEmpty()
   content: string;
@@ -23,9 +26,18 @@ export class CreatePostRequestDto {
   @ApiProperty({
     example: PostCategory.NORMAL,
     enum: PostCategory,
-    description: '게시물 유형',
+    description: '게시물 분류 (예: NORMAL, ANNOUNCEMENT)',
   })
   @IsEnum(PostCategory)
   @IsOptional()
   category?: PostCategory = PostCategory.NORMAL;
+
+  // Swagger 전용 필드 (파일은 @UploadedFile로 처리됨)
+  @ApiProperty({
+    type: 'string',
+    format: 'binary',
+    required: false,
+    description: '업로드할 이미지 파일',
+  })
+  postImage?: any;
 }

--- a/src/posts/post.swagger.ts
+++ b/src/posts/post.swagger.ts
@@ -1,115 +1,97 @@
-import { applyDecorators } from '@nestjs/common';
+import { applyDecorators, Type } from '@nestjs/common';
 import {
   ApiBody,
   ApiConsumes,
+  ApiExtraModels,
   ApiOperation,
-  ApiResponse,
   ApiParam,
+  ApiResponse,
+  getSchemaPath,
 } from '@nestjs/swagger';
-import { PostCategory } from '@prisma/client';
+import { ApiResponseDto } from 'src/common/dto/api-response.dto';
+import {
+  apiErrorResponse,
+  apiErrorResponses,
+} from 'src/common/swagger/response.helper';
+import { CreatePostRequestDto } from './dto/requests/create-post.dto';
+import { UpdatePostRequestDto } from './dto/requests/update-post.dto';
+import { PostResponseDto } from './dto/responses/post-response.dto';
 
-const unauthorizedExamples = () =>
-  ApiResponse({
-    status: 401,
-    description: '인증되지 않은 사용자',
-    content: {
-      'application/json': {
-        examples: {
-          TokenExpired: {
-            value: {
-              message: '토큰이 만료되었습니다. 다시 로그인해주세요.',
-              error: 'Unauthorized',
-              statusCode: 401,
-            },
-          },
-          InvalidToken: {
-            value: {
-              message: '유효하지 않은 토큰입니다.',
-              error: 'Unauthorized',
-              statusCode: 401,
-            },
-          },
-        },
-      },
-    },
-  });
+const badRequestExamples = {
+  MissingRequired: {
+    message: ['제목과 내용은 비워둘 수 없습니다.'],
+    error: 'Bad Request',
+    statusCode: 400,
+  },
+  InvalidCategory: {
+    message: ['category 값이 올바르지 않습니다.'],
+    error: 'Bad Request',
+    statusCode: 400,
+  },
+};
 
-const forbiddenExamples = () =>
-  ApiResponse({
-    status: 403,
-    description: '권한 없음',
-    content: {
-      'application/json': {
-        examples: {
-          NotAuthor: {
-            value: {
-              message: '게시물 수정/삭제 권한이 없습니다.',
-              error: 'Forbidden',
-              statusCode: 403,
-            },
-          },
-        },
-      },
-    },
-  });
+const unauthorizedExamples = {
+  TokenExpired: {
+    message: '토큰이 만료되었습니다. 다시 로그인해주세요.',
+    error: 'Unauthorized',
+    statusCode: 401,
+  },
+  InvalidToken: {
+    message: '유효하지 않은 토큰입니다.',
+    error: 'Unauthorized',
+    statusCode: 401,
+  },
+};
 
-const badRequestExamples = () =>
-  ApiResponse({
-    status: 400,
-    description: '잘못된 요청',
-    content: {
-      'application/json': {
-        examples: {
-          MissingRequired: {
-            value: {
-              message: ['제목과 내용은 비워둘 수 없습니다.'],
-              error: 'Bad Request',
-              statusCode: 400,
-            },
-          },
-          InvalidCategory: {
-            value: {
-              message: ['category 값이 올바르지 않습니다.'],
-              error: 'Bad Request',
-              statusCode: 400,
-            },
-          },
-        },
-      },
-    },
-  });
+const forbiddenExamples = {
+  AnnouncementForbidden: {
+    message: '공지 작성/변경은 매니저만 가능합니다',
+    error: 'Forbidden',
+    statusCode: 403,
+  },
+  AuthorForbidden: {
+    message: '게시물 수정/삭제 권한이 없습니다.',
+    error: 'Forbidden',
+    statusCode: 403,
+  },
+};
 
-const notFoundExamples = (targets: Array<'Post' | 'Group'> = ['Post']) =>
-  ApiResponse({
-    status: 404,
-    description: `${targets.join(', ')} 리소스를 찾을 수 없음`,
-    content: {
-      'application/json': {
-        examples: {
-          ...(targets.includes('Post') && {
-            PostNotFound: {
-              summary: 'PostNotFound',
-              value: {
-                message: 'ID가 {postId}인 게시물을 찾을 수 없습니다.',
-                error: 'Not Found',
-                statusCode: 404,
-              },
+const notFoundExamples = {
+  PostNotFound: {
+    message: 'ID가 {postId}인 게시물을 찾을 수 없습니다.',
+    error: 'Not Found',
+    statusCode: 404,
+  },
+  GroupNotFound: {
+    message: 'ID가 {groupId}인 그룹을 찾을 수 없습니다.',
+    error: 'Not Found',
+    statusCode: 404,
+  },
+};
+
+const apiResponseWithData = <T extends Type<any>>(
+  model: T,
+  status = 200,
+  description = '요청이 성공적으로 처리되었습니다.',
+) => {
+  return applyDecorators(
+    ApiExtraModels(ApiResponseDto, model),
+    ApiResponse({
+      status,
+      description,
+      schema: {
+        allOf: [
+          { $ref: getSchemaPath(ApiResponseDto) },
+          {
+            properties: {
+              data: { $ref: getSchemaPath(model) },
             },
-          }),
-          ...(targets.includes('Group') && {
-            GroupNotFound: {
-              summary: 'GroupNotFound',
-              value: {
-                message: 'ID가 {groupId}인 그룹을 찾을 수 없습니다.',
-                error: 'Not Found',
-                statusCode: 404,
-              },
-            },
-          }),
-        },
+          },
+        ],
       },
-    },
-  });
+    }),
+  );
+};
 
 export const ApiPosts = {
   create: () =>
@@ -118,71 +100,22 @@ export const ApiPosts = {
         summary: '게시물 생성',
         description: '새로운 게시물을 생성합니다.',
       }),
-      ApiParam({
-        name: 'groupId',
-        required: true,
-        description: '게시물이 소속될 그룹 ID',
-        schema: { type: 'integer', example: 15 },
-      }),
       ApiConsumes('multipart/form-data'),
       ApiBody({
-        schema: {
-          type: 'object',
-          properties: {
-            title: { type: 'string', example: '첫 번째 글' },
-            content: {
-              type: 'string',
-              example: '안녕하세요! 본문 내용입니다.',
-            },
-            category: {
-              type: 'string',
-              enum: Object.values(PostCategory),
-              example: PostCategory.NORMAL,
-              description: `게시물 분류 (예: ${Object.values(PostCategory).join(', ')})`,
-            },
-            postImage: {
-              type: 'string',
-              format: 'binary',
-              description: '업로드할 이미지 파일(선택)',
-            },
-          },
-          required: ['title', 'content'],
-        },
+        type: CreatePostRequestDto,
       }),
-      ApiResponse({
-        status: 201,
-        description: '게시물 생성 완료',
-        content: {
-          'application/json': {
-            example: {
-              status: 'success',
-              message: '게시물이 성공적으로 생성되었습니다.',
-              data: {
-                id: 118,
-                groupId: 15,
-                user: {
-                  id: 12,
-                  name: '권혁진',
-                  profileImageUrl:
-                    'https://modgu-main-s3.s3.ap-northeast-2.amazonaws.com/profile/1.jpg',
-                },
-                createdAt: '2025-08-08T04:42:01.057Z',
-                updatedAt: null,
-                category: 'NORMAL',
-                title: '이하',
-                content: '서',
-                postImageUrl:
-                  'https://modgu-main-s3.s3.ap-northeast-2.amazonaws.com/post/1.jpg',
-                commentsCount: 0,
-                likesCount: 0,
-                isLiked: false,
-              },
-            },
-          },
-        },
-      }),
-      badRequestExamples(),
-      unauthorizedExamples(),
+      apiResponseWithData(
+        PostResponseDto,
+        201,
+        '게시물이 성공적으로 생성되었습니다.',
+      ),
+      apiErrorResponses(400, '잘못된 요청', badRequestExamples),
+      apiErrorResponses(401, '유효하지 않은 토큰', unauthorizedExamples),
+      apiErrorResponse(
+        403,
+        '권한 없음',
+        forbiddenExamples.AnnouncementForbidden,
+      ),
     ),
 
   getAll: () =>
@@ -190,12 +123,6 @@ export const ApiPosts = {
       ApiOperation({
         summary: '그룹 내 게시물 목록 조회',
         description: '특정 그룹의 게시물 목록을 조회합니다.',
-      }),
-      ApiParam({
-        name: 'groupId',
-        required: true,
-        description: '그룹 ID',
-        schema: { type: 'integer', example: 15 },
       }),
       ApiResponse({
         status: 200,
@@ -250,63 +177,71 @@ export const ApiPosts = {
           },
         },
       }),
-      notFoundExamples(['Group']),
-      unauthorizedExamples(),
+      apiErrorResponses(401, '유효하지 않은 토큰', unauthorizedExamples),
+      apiErrorResponse(
+        404,
+        '요청한 리소스를 찾을 수 없음',
+        notFoundExamples.GroupNotFound,
+      ),
     ),
 
-  getOne: () =>
-    applyDecorators(
-      ApiOperation({
-        summary: '게시물 단건 조회',
-        description: '게시물 상세 정보를 조회합니다.',
-      }),
-      ApiParam({
-        name: 'groupId',
-        required: true,
-        description: '그룹 ID',
-        schema: { type: 'integer', example: 15 },
-      }),
-      ApiParam({
-        name: 'postId',
-        required: true,
-        description: '게시물 ID',
-        schema: { type: 'integer', example: 118 },
-      }),
-      ApiResponse({
-        status: 200,
-        description: '게시물 조회 성공',
-        content: {
-          'application/json': {
-            example: {
-              status: 'success',
-              message: '게시물을 성공적으로 가져왔습니다.',
-              data: {
-                id: 118,
-                groupId: 15,
-                user: {
-                  id: 12,
-                  name: '권혁진',
-                  profileImageUrl:
-                    'https://modgu-main-s3.s3.ap-northeast-2.amazonaws.com/profile/2.jpg',
-                },
-                createdAt: '2025-08-08T04:42:01.057Z',
-                updatedAt: null,
-                category: 'NORMAL',
-                title: '이하',
-                content: '서',
-                postImageUrl:
-                  'https://modgu-main-s3.s3.ap-northeast-2.amazonaws.com/post/2.jpg',
-                commentsCount: 1,
-                likesCount: 0,
-                isLiked: false,
-              },
-            },
-          },
-        },
-      }),
-      notFoundExamples(['Post']),
-      unauthorizedExamples(),
-    ),
+  // getOne: () =>
+  //   applyDecorators(
+  //     ApiOperation({
+  //       summary: '게시물 단건 조회',
+  //       description: '게시물 상세 정보를 조회합니다.',
+  //     }),
+  //     ApiParam({
+  //       name: 'groupId',
+  //       required: true,
+  //       description: '그룹 ID',
+  //       schema: { type: 'integer', example: 15 },
+  //     }),
+  //     ApiParam({
+  //       name: 'postId',
+  //       required: true,
+  //       description: '게시물 ID',
+  //       schema: { type: 'integer', example: 118 },
+  //     }),
+  //     ApiResponse({
+  //       status: 200,
+  //       description: '게시물 조회 성공',
+  //       content: {
+  //         'application/json': {
+  //           example: {
+  //             status: 'success',
+  //             message: '게시물을 성공적으로 가져왔습니다.',
+  //             data: {
+  //               id: 118,
+  //               groupId: 15,
+  //               user: {
+  //                 id: 12,
+  //                 name: '권혁진',
+  //                 profileImageUrl:
+  //                   'https://modgu-main-s3.s3.ap-northeast-2.amazonaws.com/profile/2.jpg',
+  //               },
+  //               createdAt: '2025-08-08T04:42:01.057Z',
+  //               updatedAt: null,
+  //               category: 'NORMAL',
+  //               title: '이하',
+  //               content: '서',
+  //               postImageUrl:
+  //                 'https://modgu-main-s3.s3.ap-northeast-2.amazonaws.com/post/2.jpg',
+  //               commentsCount: 1,
+  //               likesCount: 0,
+  //               isLiked: false,
+  //             },
+  //           },
+  //         },
+  //       },
+  //     }),
+  //     apiErrorResponse(
+  //       404,
+  //       '요청한 리소스를 찾을 수 없음',
+  //       notFoundExamples.PostNotFound,
+  //     ),
+  //     apiErrorResponses(401, '유효하지 않은 토큰', unauthorizedExamples),
+  //   ),
 
   update: () =>
     applyDecorators(
@@ -327,55 +262,17 @@ export const ApiPosts = {
         schema: { type: 'integer', example: 118 },
       }),
       ApiBody({
-        schema: {
-          type: 'object',
-          properties: {
-            title: { type: 'string', example: '수정된 제목' },
-            content: { type: 'string', example: '수정된 본문 내용' },
-            category: {
-              type: 'string',
-              enum: Object.values(PostCategory),
-              example: PostCategory.NORMAL,
-            },
-          },
-        },
+        type: UpdatePostRequestDto,
       }),
-      ApiResponse({
-        status: 200,
-        description: '게시물 수정 성공',
-        content: {
-          'application/json': {
-            example: {
-              status: 'success',
-              message: '게시물이 성공적으로 수정되었습니다.',
-              data: {
-                id: 118,
-                groupId: 15,
-                user: {
-                  id: 12,
-                  name: '권혁진',
-                  profileImageUrl:
-                    'https://modgu-main-s3.s3.ap-northeast-2.amazonaws.com/profile/1.jpg',
-                },
-                createdAt: '2025-08-08T04:42:01.057Z',
-                updatedAt: '2025-08-09T08:21:00.000Z',
-                category: 'NORMAL',
-                title: '수정된 제목',
-                content: '수정된 본문 내용',
-                postImageUrl:
-                  'https://modgu-main-s3.s3.ap-northeast-2.amazonaws.com/post/2.jpg',
-                commentsCount: 1,
-                likesCount: 0,
-                isLiked: false,
-              },
-            },
-          },
-        },
-      }),
-      badRequestExamples(),
-      notFoundExamples(['Post']),
-      forbiddenExamples(),
-      unauthorizedExamples(),
+      apiResponseWithData(
+        PostResponseDto,
+        200,
+        '게시물이 성공적으로 수정되었습니다.',
+      ),
+      apiErrorResponses(400, '잘못된 요청', badRequestExamples),
+      apiErrorResponses(401, '유효하지 않은 토큰', unauthorizedExamples),
+      apiErrorResponse(403, '권한 없음', forbiddenExamples.AuthorForbidden),
+      apiErrorResponses(404, '요청한 리소스를 찾을 수 없음', notFoundExamples),
     ),
 
   remove: () =>
@@ -409,8 +306,8 @@ export const ApiPosts = {
           },
         },
       }),
-      notFoundExamples(['Post']),
-      forbiddenExamples(),
-      unauthorizedExamples(),
+      apiErrorResponses(401, '유효하지 않은 토큰', unauthorizedExamples),
+      apiErrorResponse(403, '권한 없음', forbiddenExamples.AuthorForbidden),
+      apiErrorResponses(404, '요청한 리소스를 찾을 수 없음', notFoundExamples),
     ),
 };


### PR DESCRIPTION
관련 이슈
-
- #171 

📝 제목
-
[Refactor] Swagger 에러 응답 래핑 제거 및 공통 헬퍼 도입

📋 작업 내용
-
- [x]  Swagger 에러 응답 정의에서 `withXXX` 형태의 중간 래핑 제거
- [x] 에러 응답을 상태 코드 기준으로 명확하게 드러내는 구조로 정리
- [x] 단일/복수 에러 응답을 위한 공통 헬퍼 추가 
- [x] Comments API Swagger 데코레이터를 새로운 공통 헬퍼 기준으로 리팩토링

🔧 기술 변경
-
 <!-- 새로운 모듈/패키지 추가 -->
 <!-- 폴더/파일 구조 변경 -->

🚀 테스트 사항(선택)
-
 Swagger UI에서 에러 응답 dropdown 정상 표시 확인
 상태 코드별(400 / 401 / 403 / 404) 에러 응답 예시 확인

## 💬 리뷰 요구사항 (선택)  
Swagger 에러 응답을 문서(UI) 기준으로 단순화한 방향성에 대한 의견
동일 패턴을 다른 도메인(API)에도 적용해도 괜찮을지 검토 요청
