### PR TITLE
refactor: (#175)  refresh 토큰 재발급 흐름을 userId 기반으로 변경

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -65,21 +65,11 @@ export class AuthController {
   @ApiAuth.refresh()
   @Post('refresh')
   async refresh(
-    @Req() req: Request,
+    @Req() req: Request & { user: { userId: number } },
     @Res({ passthrough: true }) res: Response,
   ): Promise<ApiResponseDto<AuthTokenDataDto>> {
-    const refreshToken = req.cookies['refresh_token'] as string;
-    if (!refreshToken) {
-      res.status(400);
-      return {
-        status: 'fail',
-        message: 'Refresh Token이 없습니다.',
-        data: null,
-      };
-    }
-
     const { accessToken, refreshToken: newRefreshToken } =
-      await this.authService.refreshAccessToken(refreshToken);
+      await this.authService.refreshAccessToken(req.user.userId);
 
     res.cookie('refresh_token', newRefreshToken, this.getCookieOptions());
 

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,5 +1,4 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
-import { InternalServerErrorException } from '@nestjs/common/exceptions/internal-server-error.exception';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import { User } from '@prisma/client';
@@ -44,25 +43,17 @@ export class AuthService {
     return this.issueTokens(user);
   }
 
-  async refreshAccessToken(refreshToken: string): Promise<{
+  async refreshAccessToken(userId: number): Promise<{
     accessToken: string;
     refreshToken: string;
   }> {
-    try {
-      const payload = this.jwtService.verify<JwtPayload>(refreshToken, {
-        secret: this.configService.getOrThrow<string>('JWT_REFRESH_SECRET'),
-      });
-      const user = await this.usersService.findUserById(payload.sub);
-      if (!user) {
-        throw new BadRequestException('유효하지 않은 사용자입니다.');
-      }
-      return this.issueTokens(user);
-    } catch (e: unknown) {
-      if (e instanceof Error) {
-        console.log(`에러 발생: ${e.message}`, e.stack);
-      }
-      throw new InternalServerErrorException();
+    const user = await this.usersService.findUserById(userId);
+
+    if (!user) {
+      throw new BadRequestException('유효하지 않은 사용자입니다.');
     }
+
+    return this.issueTokens(user);
   }
 
   async oauthLogin(params: OAuthInput): Promise<{

--- a/src/auth/strategies/refresh.strategy.ts
+++ b/src/auth/strategies/refresh.strategy.ts
@@ -21,9 +21,9 @@ export class JwtRefreshStrategy extends PassportStrategy(
     });
   }
 
-  async validate(payload: JwtPayload) {
+  async validate(payload: JwtPayload): Promise<{ userId: number }> {
     return {
-      username: payload.username,
+      userId: payload.sub,
     };
   }
 }


### PR DESCRIPTION
관련 이슈
-
 Close #175 

📋 작업 내용
-
- [x]  refresh 재발급 흐름 리팩터링
- [x]  서비스 계층 책임 분리

🔧 기술 변경
-
- `AuthService.refreshAccessToken`의 인자를 `refreshToken: string`에서 `userId: number`로 변경했습니다.
- `JwtRefreshStrategy.validate`가 검증된 사용자 식별자(`userId`)를 반환하도록 수정했습니다.
- 서비스 계층에서 리프레시 토큰을 직접 파싱/검증하던 중복 로직을 제거하고, 토큰 재발급 책임에 집중하도록 구조를 정리했습니다.

🚀 테스트 사항(선택)
-
 refresh token 재발급 성공 흐름 확인
 refresh 인증 실패 응답 확인
 e2e 테스트 실행 및 동작 확인
